### PR TITLE
fix file not closed when loader is not filly iterated

### DIFF
--- a/jubakit/loader/core.py
+++ b/jubakit/loader/core.py
@@ -17,11 +17,13 @@ class LineBasedStreamLoader(BaseLoader):
     self._lines = 0
 
   def __iter__(self):
-    for line in self._f:
-      yield self.preprocess({str(self._lines): line})
-      self._lines += 1
-    if self._close:
-      self._f.close()
+    try:
+      for line in self._f:
+        yield self.preprocess({str(self._lines): line})
+        self._lines += 1
+    finally:
+      if not self._f.closed and self._close:
+        self._f.close()
 
   def preprocess(self, ent):
     return {'line': list(ent.values())[0]}

--- a/jubakit/test/loader/test_core.py
+++ b/jubakit/test/loader/test_core.py
@@ -3,8 +3,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from unittest import TestCase
-
 from io import StringIO
+from tempfile import NamedTemporaryFile as TempFile
+
 from jubakit.loader.core import LineBasedStreamLoader, LineBasedFileLoader
 
 class LineBasedStreamLoaderTest(TestCase):
@@ -16,5 +17,20 @@ class LineBasedStreamLoaderTest(TestCase):
     lines = []
     for line in loader:
       lines.append(line)
+
+    self.assertEqual([{'line': 'hello\n'}, {'line': 'world'}], lines)
+
+class LineBasedFileLoaderTest(TestCase):
+  def test_simple(self):
+    data = 'hello\nworld'
+    lines = []
+
+    with TempFile() as f:
+      f.write(data.encode())
+      f.flush()
+      loader = LineBasedFileLoader(f.name)
+
+      for line in loader:
+        lines.append(line)
 
     self.assertEqual([{'line': 'hello\n'}, {'line': 'world'}], lines)


### PR DESCRIPTION
LineBasedStreamLoader did not close a file if the data loading is terminated before reading all lines of the file.