### PR TITLE
make Loader API public

### DIFF
--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -32,14 +32,24 @@ class BaseLoader(object):
     """
     Preprocesses the given dict-like object into another dict-like object.
     The default implementation does not alter the object.  Users can override
-    this method to perform custom process.
+    this method to perform custom process.  You can yield None to skip the
+    record.
     """
     return ent
 
   def __iter__(self):
     """
+    Loads each row from the data source.
+    """
+    for ent in self.rows():
+      processed = self.preprocess(ent)
+      if processed is not None:
+        yield processed
+
+  def rows(self):
+    """
     Subclasses must override this method and yield each row of data source
-    in dict-like object.  You can yield None to skip the record.
+    in flat dict-like object.  You can yield None to skip the record.
     """
     raise NotImplementedError()
 

--- a/jubakit/loader/array.py
+++ b/jubakit/loader/array.py
@@ -27,9 +27,9 @@ class ArrayLoader(BaseLoader):
     self._array = array
     self._feature_names = feature_names
 
-  def __iter__(self):
+  def rows(self):
     for ent in self._array:
-      yield self.preprocess(dict([x for x in zip(self._feature_names, ent) if x[1] is not None]))
+      yield dict([x for x in zip(self._feature_names, ent) if x[1] is not None])
 
 class ZipArrayLoader(BaseLoader):
   """
@@ -63,6 +63,6 @@ class ZipArrayLoader(BaseLoader):
       self._feature_names.append(name)
       self._arrays.append(named_arrays[name])
 
-  def __iter__(self):
+  def rows(self):
     for ent in zip(*self._arrays):
-      yield self.preprocess(dict([x for x in zip(self._feature_names, ent) if x[1] is not None]))
+      yield dict([x for x in zip(self._feature_names, ent) if x[1] is not None])

--- a/jubakit/loader/chain.py
+++ b/jubakit/loader/chain.py
@@ -17,12 +17,12 @@ class MergeChainLoader(BaseLoader):
   def __init__(self, *loaders):
     self._loaders = loaders
 
-  def __iter__(self):
+  def rows(self):
     for ent in zip_longest(*self._loaders, fillvalue={}):
       merged = {}
       for d in ent:
         merged.update(d)
-      yield self.preprocess(merged)
+      yield merged
 
 class ValueMapChainLoader(BaseLoader):
   """
@@ -35,7 +35,7 @@ class ValueMapChainLoader(BaseLoader):
     self._key = key
     self._mapping = mapping
 
-  def __iter__(self):
+  def rows(self):
     for ent in self._loader:
       ent[self._key] = self._mapping[ent[self._key]]
-      yield self.preprocess(ent)
+      yield ent

--- a/jubakit/loader/core.py
+++ b/jubakit/loader/core.py
@@ -16,17 +16,14 @@ class LineBasedStreamLoader(BaseLoader):
     self._close = close
     self._lines = 0
 
-  def __iter__(self):
+  def rows(self):
     try:
       for line in self._f:
-        yield self.preprocess({str(self._lines): line})
+        yield {"number": self._lines, "line": line}
         self._lines += 1
     finally:
       if not self._f.closed and self._close:
         self._f.close()
-
-  def preprocess(self, ent):
-    return {'line': list(ent.values())[0]}
 
 class LineBasedFileLoader(LineBasedStreamLoader):
   """

--- a/jubakit/loader/csv.py
+++ b/jubakit/loader/csv.py
@@ -42,7 +42,7 @@ class CSVLoader(BaseLoader):
     self._args = args
     self._kwargs = kwargs
 
-  def __iter__(self):
+  def rows(self):
     def _encode_file(f, enc):
       for line in f: yield line.encode(enc)
     def _decode_row(r, enc):
@@ -53,4 +53,4 @@ class CSVLoader(BaseLoader):
       reader = csv.DictReader(f, fieldnames=self._fieldnames, *self._args, **self._kwargs)
       for row in reader:
         ent = row if PYTHON3 else _decode_row(row, self._encoding)
-        yield self.preprocess(ent)
+        yield ent

--- a/jubakit/loader/sparse.py
+++ b/jubakit/loader/sparse.py
@@ -15,7 +15,7 @@ class SparseMatrixLoader(BaseLoader):
     self._matrix = matrix.tocsr()
     self._feature_names = feature_names
 
-  def __iter__(self):
+  def rows(self):
     m = self._matrix
     for i in range(m.shape[0]):
       cols = m.indices[m.indptr[i]:m.indptr[i+1]]
@@ -26,4 +26,4 @@ class SparseMatrixLoader(BaseLoader):
         fv_names = [self._feature_names[col] for col in cols]
 
       data = dict(zip(fv_names, m.data[m.indptr[i]:m.indptr[i+1]]))
-      yield self.preprocess(data)
+      yield data

--- a/jubakit/loader/twitter.py
+++ b/jubakit/loader/twitter.py
@@ -90,7 +90,7 @@ class TwitterStreamLoader(BaseLoader):
   def _on_event(self, event):
     self._queue.put(event)
 
-  def __iter__(self):
+  def rows(self):
     self._thread.start()
     exception = None
     try:

--- a/jubakit/test/loader/test_core.py
+++ b/jubakit/test/loader/test_core.py
@@ -18,7 +18,7 @@ class LineBasedStreamLoaderTest(TestCase):
     for line in loader:
       lines.append(line)
 
-    self.assertEqual([{'line': 'hello\n'}, {'line': 'world'}], lines)
+    self.assertEqual([{'line': 'hello\n', 'number': 0}, {'line': 'world', 'number': 1}], lines)
 
 class LineBasedFileLoaderTest(TestCase):
   def test_simple(self):
@@ -33,4 +33,4 @@ class LineBasedFileLoaderTest(TestCase):
       for line in loader:
         lines.append(line)
 
-    self.assertEqual([{'line': 'hello\n'}, {'line': 'world'}], lines)
+    self.assertEqual([{'line': 'hello\n', 'number': 0}, {'line': 'world', 'number': 1}], lines)

--- a/jubakit/test/stub.py
+++ b/jubakit/test/stub.py
@@ -11,19 +11,19 @@ from jubakit.base import BaseLoader, BaseSchema, BaseDataset, BaseService, BaseC
 class StubLoader(BaseLoader):
   DATA = [1,2,3]
 
-  def __iter__(self):
+  def rows(self):
     for d in self.DATA:
-      yield self.preprocess({'v': d})
+      yield {'v': d}
       yield None  # None should be ignored by Dataset
 
 class StubInfiniteLoader(BaseLoader):
   def is_infinite(self):
     return True
 
-  def __iter__(self):
+  def rows(self):
     d = 1
     while True:
-      yield self.preprocess({'v': d})
+      yield {'v': d}
       d += 1
 
 class StubService(BaseService):


### PR DESCRIPTION
This fix makes Loader API public (method name without underscore: `rows()` instead of `__iter__`), so users can implement their own loaders easily.