### PR TITLE
add seed option to Dataset.shuffle

### DIFF
--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -263,7 +263,7 @@ class BaseDataset(object):
     """
     return self._schema
 
-  def shuffle(self):
+  def shuffle(self, seed=None):
     """
     Returns a new immutable Dataset whose records are shuffled.
     """
@@ -271,7 +271,7 @@ class BaseDataset(object):
       raise RuntimeError('non-static datasets cannot be shuffled')
 
     def _shuffle(data):
-      return random.sample(data, len(data))
+      return random.Random(seed).sample(data, len(data))
     return self.convert(_shuffle)
 
   def convert(self, func):

--- a/jubakit/test/test_base.py
+++ b/jubakit/test/test_base.py
@@ -184,7 +184,7 @@ class BaseDatasetTest(TestCase):
 
   def test_shuffle(self):
     loader = StubLoader()
-    ds = BaseDataset(loader, self.SCHEMA).shuffle()
+    ds = BaseDataset(loader, self.SCHEMA).shuffle(0)
 
     rows = []
     for (_, row) in ds:


### PR DESCRIPTION
Online machine learning depends on the order of training instances.
To make experiments reproducible, this PR adds `seed` option to `Dataset.shuffle` method.