### PR TITLE
improve add_mecab method to accept list as a feature filter

### DIFF
--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -749,6 +749,11 @@ class GenericConfig(BaseConfig):
     """
     Add MeCab feature extraction to string_types.
     """
+    if isinstance(include_features, list):
+      include_features = '|'.join(include_features)
+
+    if isinstance(exclude_features, list):
+      exclude_features = '|'.join(exclude_features)
 
     self['converter']['string_types'][name] = {
       'method': 'dynamic',

--- a/jubakit/test/test_base.py
+++ b/jubakit/test/test_base.py
@@ -271,7 +271,9 @@ class TestGenericConfg(TestCase):
   def test_add_mecab(self):
     config = StubGenericConfig()
     self.assertFalse('mecab2' in config['converter']['string_types'])
-    config.add_mecab(name='mecab2', ngram=2, base=True)
+    config.add_mecab(name='mecab2', ngram=2, base=True, include_features='名詞,*', exclude_features=['動詞,*', '形容詞,*'])
     self.assertTrue('mecab2' in config['converter']['string_types'])
     self.assertEqual('2', config['converter']['string_types']['mecab2']['ngram'])
     self.assertEqual('true', config['converter']['string_types']['mecab2']['base'])
+    self.assertEqual('名詞,*', config['converter']['string_types']['mecab2']['include_features'])
+    self.assertEqual('動詞,*|形容詞,*', config['converter']['string_types']['mecab2']['exclude_features'])


### PR DESCRIPTION
MeCab feature filters (`{include,exclude}_features`) now accepts list.