### PR TITLE
fix config unused in classifier_bulk example

### DIFF
--- a/example/classifier_bulk.py
+++ b/example/classifier_bulk.py
@@ -33,7 +33,7 @@ cfg = Config()
 
 # Bulk train-test the classifier.
 result = Classifier.train_and_classify(
-  Config(),
+  cfg,
   dataset[:n_train_samples],
   dataset[n_train_samples:],
   sklearn.metrics.classification_report


### PR DESCRIPTION
Fix a bug in `classifier_bulk.py` example that created config instance is not used.