### PR TITLE
Code quality improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,11 @@ script:
     - pip install -e.[test]
 
     # Unit Test
-    - coverage run setup.py test
+    - coverage run -p setup.py test
 
     # Integration Test
-    - export PYTHONPATH="."
-    - coverage run --append tools/run_examples.py
+    - coverage run -p tools/run_examples.py
 
 after_success:
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then coveralls; fi
+    - coverage combine
+    - coveralls

--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -147,11 +147,7 @@ class GenericSchema(BaseSchema):
     elif t == self.AUTO or t == self.INFER:
       (pred_type, pred_v) = self._predict_type(v, (t == self.AUTO))
       _logger.debug('key %s predicted as type %s', k, pred_type)
-      try:
-        self._add_to_datum(d, pred_type, k, pred_v)
-      except:
-        _logger.debug('key %s with value %s cannot be added as %s', k, v, pred_type)
-        raise
+      self._add_to_datum(d, pred_type, k, pred_v)
     elif t == self.IGNORE:
       pass
     else:

--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -252,8 +252,6 @@ class BaseDataset(object):
       # Load all data entries.
       _logger.info('loading all records from loader %s', loader)
       for row in loader:
-        if row is None:
-          continue
         # Predict schema.
         if self._schema is None:
           self._schema = self._predict(row)
@@ -367,6 +365,7 @@ class BaseDataset(object):
       self._index = 0
       for row in source:
         if row is None:
+          # May contain None in self._data if Dataset.convert is used.
           continue
         self._buffer = row
         yield (self._index, self._schema.transform(row))

--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -708,7 +708,7 @@ class GenericConfig(BaseConfig):
       default_parameter = self._default_parameter(method)
       if default_parameter is None:
         if 'parameter' in self: del self['parameter']
-      elif default_parameter is not None:
+      else:
         self['parameter'] = default_parameter
 
     if parameter is not None:

--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -615,9 +615,9 @@ class _ServiceBackend(object):
     for i in range(10):
       time.sleep(sleep_time/1000000.0) # from usec to sec
       if cls._ping_rpc(port):
+        _logger.debug('service RPC ready after %d tries', i)
         return True
       sleep_time *= 2
-    _logger.debug('service RPC ready in %d tries', i)
     return False
 
   @classmethod

--- a/jubakit/classifier.py
+++ b/jubakit/classifier.py
@@ -101,7 +101,7 @@ class Dataset(BaseDataset):
     """
 
     if not self._static:
-      raise RuntimeException('non-static datasets cannot fetch list of labels')
+      raise RuntimeError('non-static datasets cannot fetch list of labels')
 
     for (idx, (label, d)) in self:
       yield label

--- a/jubakit/compat.py
+++ b/jubakit/compat.py
@@ -5,17 +5,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 import itertools
 
-if sys.version_info < (3, 0):
+PYTHON3 = sys.version_info >= (3, 0)
+
+zip_longest = itertools.zip_longest if PYTHON3 else itertools.izip_longest
+unicode_t = str if PYTHON3 else unicode
+long_t = int if PYTHON3 else long
+
+if not PYTHON3:
   # Python 2.x
-  PYTHON3 = False
   range = xrange
   zip = itertools.izip
-  zip_longest = itertools.izip_longest
-  unicode_t = unicode
-  long_t = long
-else:
-  # Python 3.x
-  PYTHON3 = True
-  zip_longest = itertools.zip_longest
-  unicode_t = str
-  long_t = int

--- a/jubakit/logger.py
+++ b/jubakit/logger.py
@@ -11,12 +11,15 @@ from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
 # Define the default logging format.
 _DEFAULT_FORMAT = '[%(name)s] %(asctime)s: (%(levelname)s) %(message)s'
 
+# jubakit root logger name.
+_LOGGER_NAME = 'jubakit'
+
 # Define the defualt logger which does nothing.
 class _NullHandler(logging.Handler):
   def emit(self, record):
     pass
 
-_logger = logging.getLogger('jubakit')
+_logger = logging.getLogger(_LOGGER_NAME)
 _logger.addHandler(_NullHandler())
 _logger.setLevel(logging.CRITICAL)
 
@@ -42,4 +45,7 @@ def get_logger(name=None):
   """
   if name is None:
     return _logger
-  return _logger.getChild(name)
+  elif hasattr(_logger, 'getChild'):
+    return _logger.getChild(name)
+  else:
+    return logging.getLogger('{0}.{1}'.format(_LOGGER_NAME, name))

--- a/jubakit/test/loader/test_core.py
+++ b/jubakit/test/loader/test_core.py
@@ -20,6 +20,15 @@ class LineBasedStreamLoaderTest(TestCase):
 
     self.assertEqual([{'line': 'hello\n', 'number': 0}, {'line': 'world', 'number': 1}], lines)
 
+  def test_close(self):
+    data = 'hello\nworld'
+
+    f = StringIO(data)
+    loader = LineBasedStreamLoader(f, False)  # do not close
+    for _ in loader: pass
+
+    self.assertFalse(f.closed)
+
 class LineBasedFileLoaderTest(TestCase):
   def test_simple(self):
     data = 'hello\nworld'

--- a/jubakit/test/loader/test_csv.py
+++ b/jubakit/test/loader/test_csv.py
@@ -24,6 +24,13 @@ class CSVLoaderTest(TestCase):
         else:
           self.fail('unexpected row')
 
+  def test_guess_header(self):
+    with TempFile() as f:
+      f.write("k1,k2,k3\n1,2,3".encode())
+      f.flush()
+      loader = CSVLoader(f.name, fieldnames=True)
+      self.assertEqual([{'k1': '1', 'k2': '2', 'k3': '3'}], list(loader))
+
   def test_noheader(self):
     with TempFile() as f:
       f.write("1,\"2\",3\n\"4\",5,\"6\"".encode('utf-8'))

--- a/jubakit/test/loader/test_twitter.py
+++ b/jubakit/test/loader/test_twitter.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.loader.twitter import TwitterStreamLoader, TwitterOAuthHandler
+
+class TwitterStreamLoaderTest(TestCase):
+  oauth = TwitterOAuthHandler(consumer_key='x', consumer_secret='x', access_token='x', access_secret='x')
+
+  def test_simple(self):
+    loader = TwitterStreamLoader(self.oauth)
+
+  def test_errors(self):
+    # auth info (both os.environ and auth argument) is not set
+    self.assertRaises(RuntimeError, TwitterStreamLoader)
+
+    # invalid stream name
+    self.assertRaises(RuntimeError, TwitterStreamLoader, self.oauth, 'invalid_mode')

--- a/jubakit/test/stub.py
+++ b/jubakit/test/stub.py
@@ -55,3 +55,8 @@ class StubGenericConfig(GenericConfig):
       return None
     elif method == 'test2':
       return {'param1': 1, 'param2': 2}
+
+class StubGenericConfigWithoutConverter(StubGenericConfig):
+  @classmethod
+  def _default_converter(cls):
+    return None

--- a/jubakit/test/test_base.py
+++ b/jubakit/test/test_base.py
@@ -3,18 +3,25 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from unittest import TestCase
+from jubatus.common import Datum
 
 from jubakit.base import BaseLoader, BaseSchema, GenericSchema, BaseDataset, BaseService, BaseConfig, GenericConfig
 
 from .stub import *
 
 class BaseLoaderTest(TestCase):
-  def test_simple(self):
+  def test_base(self):
     loader = BaseLoader()
     self.assertFalse(loader.is_infinite())
+    self.assertRaises(NotImplementedError, loader.rows)
+
+  def test_simple(self):
+    loader = StubLoader()
+    # None should not appear.
+    self.assertEqual([{'v': 1}, {'v': 2}, {'v': 3}], list(loader))
 
 class BaseSchemaTest(TestCase):
-  def test_simple(self):
+  def test_base(self):
     schema = BaseSchema({
       'k1': BaseSchema.IGNORE,
       'k2': BaseSchema.AUTO,
@@ -78,40 +85,48 @@ class GenericSchemaTest(TestCase):
     })
 
   def test_auto(self):
+    binary_data = 'テスト'.encode('cp932')
+
     schema = GenericSchema({
       'k1': GenericSchema.AUTO,
       'k2': GenericSchema.AUTO,
       'k3': GenericSchema.AUTO,
       'k4': GenericSchema.AUTO,
+      'k5': GenericSchema.AUTO,
     })
     d = schema.transform({
       'k1': '123',
       'k2': 456,
       'k3': '789'.encode(),
       'k4': 'xxx'.encode(),
+      'k5': binary_data,
     })
 
     self.assertEqual({'k1': '123'}, dict(d.string_values))
     self.assertEqual({'k2': 456}, dict(d.num_values))
-    self.assertEqual({'k3': '789'.encode(), 'k4': 'xxx'.encode()}, dict(d.binary_values))
+    self.assertEqual({'k3': '789'.encode(), 'k4': 'xxx'.encode(), 'k5': binary_data}, dict(d.binary_values))
 
   def test_infer(self):
+    binary_data = 'テスト'.encode('cp932')
+
     schema = GenericSchema({
       'k1': GenericSchema.INFER,
       'k2': GenericSchema.INFER,
       'k3': GenericSchema.INFER,
       'k4': GenericSchema.INFER,
+      'k5': GenericSchema.INFER,
     })
     d = schema.transform({
       'k1': '123',
       'k2': 456,
       'k3': '789'.encode(),
       'k4': 'xxx'.encode(),
+      'k5': binary_data,
     })
 
     self.assertEqual({'k4': 'xxx'}, dict(d.string_values))
     self.assertEqual({'k1': 123, 'k2': 456, 'k3': 789}, dict(d.num_values))
-    self.assertEqual({}, dict(d.binary_values))
+    self.assertEqual({'k5': binary_data}, dict(d.binary_values))
 
   def test_ignore(self):
     schema = GenericSchema({
@@ -125,6 +140,20 @@ class GenericSchemaTest(TestCase):
     self.assertEqual({}, dict(d.string_values))
     self.assertEqual({'k1': 123}, dict(d.num_values))
     self.assertEqual({}, dict(d.binary_values))
+
+  def test_transform_as_datum(self):
+    d = Datum()
+
+    schema = GenericSchema({
+      'k1': GenericSchema.NUMBER,
+    }, GenericSchema.IGNORE)
+    d2 = schema._transform_as_datum({
+      'k1': '123',
+      'k2': 456,
+    }, d)
+
+    self.assertEqual(d2, d)
+    self.assertEqual({'k1': 123}, dict(d.num_values))
 
   def test_predict(self):
     row = {'num1': 10, 'num2': 10.0, 'num3': 'inf', 'str1': 'abc', 'str2': '0.0.1'}
@@ -142,7 +171,11 @@ class GenericSchemaTest(TestCase):
     self.assertEqual({'str1': 'abc', 'str2': '0.0.1', 'num3': 'inf'}, dict(d.string_values))
     self.assertEqual({'num1': 10, 'num2': 10.0}, dict(d.num_values))
 
-  def test_invalid(self):
+  def test_invalid_predict(self):
+    schema = GenericSchema({'k1': GenericSchema.STRING})
+    self.assertRaises(ValueError, schema.predict, {'k1': object()}, True)
+
+  def test_invalid_transform(self):
     schema = GenericSchema({'k1': 'unknown'})
     self.assertRaises(RuntimeError, schema.transform, {'k1': '123'})
 
@@ -177,6 +210,15 @@ class BaseDatasetTest(TestCase):
       self.assertEqual({'value': idx+1}, dict(row.num_values))
       expected_idx += 1
 
+  def test_invalid_infinite_static(self):
+    loader = StubInfiniteLoader()  # infinite loader
+    self.assertRaises(RuntimeError, BaseDataset, loader, None, True)  # cannot be static
+
+  def test_predict(self):
+    loader = StubLoader()
+    ds = BaseDataset(loader, self.SCHEMA)
+    self.assertRaises(NotImplementedError, ds._predict, {})
+
   def test_get_schema(self):
     loader = StubLoader()
     ds = BaseDataset(loader, self.SCHEMA)
@@ -192,6 +234,30 @@ class BaseDatasetTest(TestCase):
 
     row_values = [x.num_values[0][1] for x in rows]
     self.assertEqual([1,2,3], sorted(row_values))
+
+  def test_convert(self):
+    loader = StubLoader()
+    ds1 = BaseDataset(loader, self.SCHEMA)
+    def f(d):
+      new_d = {}
+      for (k, v) in d.items():
+        new_d[k] = d[k] + 1
+      return new_d
+    ds2 = ds1.convert(lambda data: [f(d) for d in data])
+    self.assertEqual(1, ds1[0].num_values[0][1])
+    self.assertEqual(2, ds2[0].num_values[0][1])
+
+  def test_convert_empty(self):
+    loader = StubLoader()
+    ds1 = BaseDataset(loader, self.SCHEMA)
+    ds2 = ds1.convert(lambda data: [None for d in data])  # ds2 should be empty
+    for d in ds2:
+      self.fail()
+
+  def test_invalid_convert(self):
+    loader = StubLoader()
+    ds1 = BaseDataset(loader, self.SCHEMA)
+    self.assertRaises(RuntimeError, ds1.convert, lambda x: None)
 
   def test_nonstatic(self):
     loader = StubLoader()
@@ -210,6 +276,7 @@ class BaseDatasetTest(TestCase):
     loader = StubLoader()
     ds = BaseDataset(loader, self.SCHEMA, False)
 
+    self.assertRaises(RuntimeError, ds.shuffle, 0)
     self.assertRaises(RuntimeError, ds.convert, lambda x:x)
     self.assertRaises(RuntimeError, ds.get, 0)
     self.assertRaises(RuntimeError, len, ds)
@@ -228,16 +295,40 @@ class BaseDatasetTest(TestCase):
       if 10 < expected_idx:
         break
 
+  def test_index_access(self):
+    loader = StubLoader()
+    ds = BaseDataset(loader, self.SCHEMA)
+    self.assertTrue(isinstance(ds[0], jubatus.common.Datum))
+    self.assertTrue(isinstance(ds[0:1], BaseDataset))
+
 class TestBaseService(TestCase):
   def test_simple(self):
+    service = BaseService()
+    self.assertRaises(NotImplementedError, service.name)
+    self.assertRaises(NotImplementedError, service._client)
+    self.assertRaises(NotImplementedError, service._client_class)
+
+  def test_stub(self):
     service = StubService()
+    self.assertRaises(RuntimeError, service.run, StubConfig())  # juba_stub does not exist
+    service.stop()
 
 class TestBaseConfig(TestCase):
+  def test_base(self):
+    self.assertRaises(NotImplementedError, BaseConfig)
+
   def test_simple(self):
     config = StubConfig()
     self.assertEqual({'test': 1.0}, config)
 
 class TestGenericConfg(TestCase):
+  def test_base(self):
+    self.assertRaises(NotImplementedError, GenericConfig)
+    self.assertRaises(NotImplementedError, GenericConfig.methods)
+    self.assertRaises(NotImplementedError, GenericConfig._default_method)
+    self.assertRaises(NotImplementedError, GenericConfig._default_parameter, None)
+    self.assertTrue(isinstance(GenericConfig._default_converter(), dict))
+
   def test_simple(self):
     config = StubGenericConfig()
     self.assertEqual('test', config['method'])
@@ -262,6 +353,12 @@ class TestGenericConfg(TestCase):
     self.assertTrue('string_rules' in config['converter'])
     self.assertEqual(0, len(config['converter']['string_types']))
 
+  def test_without_converter(self):
+    config = StubGenericConfigWithoutConverter(converter={})
+    self.assertEqual('test', config['method'])
+    self.assertTrue('parameter' not in config)
+    self.assertEqual({}, config['converter'])
+
   def test_clear_converter(self):
     config = StubGenericConfig()
     self.assertTrue('unigram' in config['converter']['string_types'])
@@ -277,3 +374,11 @@ class TestGenericConfg(TestCase):
     self.assertEqual('true', config['converter']['string_types']['mecab2']['base'])
     self.assertEqual('名詞,*', config['converter']['string_types']['mecab2']['include_features'])
     self.assertEqual('動詞,*|形容詞,*', config['converter']['string_types']['mecab2']['exclude_features'])
+
+    self.assertFalse('mecab3' in config['converter']['string_types'])
+    config.add_mecab(name='mecab3', ngram="3", base=False, include_features=['名詞,*','動詞,*'], exclude_features='動詞,*|名詞,固有名詞,*')
+    self.assertTrue('mecab3' in config['converter']['string_types'])
+    self.assertEqual('3', config['converter']['string_types']['mecab3']['ngram'])
+    self.assertEqual('false', config['converter']['string_types']['mecab3']['base'])
+    self.assertEqual('名詞,*|動詞,*', config['converter']['string_types']['mecab3']['include_features'])
+    self.assertEqual('動詞,*|名詞,固有名詞,*', config['converter']['string_types']['mecab3']['exclude_features'])

--- a/jubakit/test/test_logger.py
+++ b/jubakit/test/test_logger.py
@@ -14,3 +14,15 @@ class LoggerTest(TestCase):
     buf = StringIO()
     setup_logger(level=INFO, f=buf)
     get_logger().info(self.MESSAGE)
+    buf.seek(0)
+    msg = buf.read()
+    self.assertTrue(self.MESSAGE in msg)
+
+  def test_child(self):
+    buf = StringIO()
+    setup_logger(level=INFO, f=buf)
+    get_logger('child').info(self.MESSAGE)
+    buf.seek(0)
+    msg = buf.read()
+    self.assertTrue(self.MESSAGE in msg)
+    self.assertTrue('jubakit.child' in msg)


### PR DESCRIPTION
This PR contains multiple code improvements.

* Add test codes.
* Remove redundant error checking and conditions.
* Rewrite `compat` library which could not be well-tested.

Also fixes following minor bugs that does not affect functionality; they were discovered when adding test.

* Fix `Classifier.get_label` API not throwing correct Exception when the dataset is not static.
* Fix `get_logger` not working on Python 2.6.  We now avoid using Python 2.7 API (`getChild`).
* Fix wrong location of a debug log.