### PR TITLE
remove None and empty string with NUMBER schema

### DIFF
--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -138,10 +138,13 @@ class GenericSchema(BaseSchema):
     """
     Add value `v` whose type and name are `t` and `k` resp. to Datum `d`.
     """
+    if v is None:
+      return
     if t == self.STRING:
       d.add_string(k, unicode_t(v))
     elif t == self.NUMBER:
-      d.add_number(k, float(v))
+      if v != '':
+        d.add_number(k, float(v))
     elif t == self.BINARY:
       d.add_binary(k, v)
     elif t == self.AUTO or t == self.INFER:

--- a/jubakit/test/test_base.py
+++ b/jubakit/test/test_base.py
@@ -65,6 +65,32 @@ class GenericSchemaTest(TestCase):
     self.assertEqual({'k1': '123'}, dict(d.string_values))
     self.assertEqual({'k2': 456, 'k3': 789}, dict(d.num_values))
 
+  def test_empty(self):
+    schema = GenericSchema({
+      'k1': GenericSchema.STRING,
+      'k2': GenericSchema.NUMBER,
+    })
+    d = schema.transform({
+      'k1': '',
+      'k2': '',
+    })
+
+    self.assertEqual({'k1': ''}, dict(d.string_values))
+    self.assertEqual({}, dict(d.num_values))
+
+  def test_null(self):
+    schema = GenericSchema({
+      'k1': GenericSchema.STRING,
+      'k2': GenericSchema.NUMBER,
+    })
+    d = schema.transform({
+      'k1': None,
+      'k2': None,
+    })
+
+    self.assertEqual({}, dict(d.string_values))
+    self.assertEqual({}, dict(d.num_values))
+
   def test_unknown_key_name(self):
     schema = GenericSchema({
       'k1': GenericSchema.STRING,


### PR DESCRIPTION
This PR fixes Schema to remove the following record on transformation:

* keys whose value is `None`
* keys whose value is empty string and is typed with NUMBER schema (i.e., `NA`)