### PR TITLE
fix deprecated test warning

### DIFF
--- a/jubakit/test/test_anomaly.py
+++ b/jubakit/test/test_anomaly.py
@@ -66,5 +66,5 @@ class ConfigTest(TestCase):
 
   def test_method_param(self):
     self.assertTrue(Config(method='lof')['parameter']['ignore_kth_same_point'])
-    self.assertEquals('inverted_index_euclid', Config(method='lof')['parameter']['method'])
-    self.assertEquals('euclid_lsh', Config(method='light_lof')['parameter']['method'])
+    self.assertEqual('inverted_index_euclid', Config(method='lof')['parameter']['method'])
+    self.assertEqual('euclid_lsh', Config(method='light_lof')['parameter']['method'])


### PR DESCRIPTION
Python 3.5 emits DeprecationWarning when using `assertEquals` which is deprecated.