### PR TITLE
fix anomaly to validate invalid method name

### DIFF
--- a/jubakit/anomaly.py
+++ b/jubakit/anomaly.py
@@ -130,4 +130,6 @@ class Config(GenericConfig):
         'threads': -1,  # use number of logical CPU cores
         'hash_num': 64,
       }
+    else:
+      raise RuntimeError('unknown method: {0}'.format(method))
     return params

--- a/jubakit/test/test_anomaly.py
+++ b/jubakit/test/test_anomaly.py
@@ -68,3 +68,6 @@ class ConfigTest(TestCase):
     self.assertTrue(Config(method='lof')['parameter']['ignore_kth_same_point'])
     self.assertEqual('inverted_index_euclid', Config(method='lof')['parameter']['method'])
     self.assertEqual('euclid_lsh', Config(method='light_lof')['parameter']['method'])
+
+  def test_invalid_method(self):
+    self.assertRaises(RuntimeError, Config._default_parameter, 'invalid_method')


### PR DESCRIPTION
Fix Anomaly service to validate the invalid method name.