### PR TITLE
Fix handling of numpy data

### DIFF
--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -160,8 +160,10 @@ class GenericSchema(BaseSchema):
     if t == self.STRING:
       d.add_string(k, unicode_t(v))
     elif t == self.NUMBER:
-      if v != '':
-        d.add_number(k, float(v))
+      # Empty unicode/bytes values cannot be cast to float; treat them as NA.
+      if isinstance(v, (unicode_t, bytes)) and len(v) == 0:
+        return
+      d.add_number(k, float(v))
     elif t == self.BINARY:
       d.add_binary(k, v)
     elif t == self.AUTO or t == self.INFER:

--- a/jubakit/test/test_base.py
+++ b/jubakit/test/test_base.py
@@ -3,10 +3,17 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from unittest import TestCase
+
+try:
+  import numpy as np
+except ImportError:
+  pass
+
 from jubatus.common import Datum
 
 from jubakit.base import BaseLoader, BaseSchema, GenericSchema, BaseDataset, BaseService, BaseConfig, GenericConfig
 
+from . import requireSklearn
 from .stub import *
 
 class BaseLoaderTest(TestCase):
@@ -76,14 +83,30 @@ class GenericSchemaTest(TestCase):
     schema = GenericSchema({
       'k1': GenericSchema.STRING,
       'k2': GenericSchema.NUMBER,
+      'k3': GenericSchema.NUMBER,
     })
     d = schema.transform({
       'k1': '',
       'k2': '',
+      'k3': b'',
     })
 
     self.assertEqual({'k1': ''}, dict(d.string_values))
     self.assertEqual({}, dict(d.num_values))
+
+  @requireSklearn
+  def test_numpy(self):
+    schema = GenericSchema({
+      'k1': GenericSchema.STRING,
+      'k2': GenericSchema.NUMBER,
+    })
+    d = schema.transform({
+      'k1': np.float64(1.0),
+      'k2': np.float64(1.0),
+    })
+
+    self.assertEqual({'k1': '1.0'}, dict(d.string_values))
+    self.assertEqual({'k2': 1.0}, dict(d.num_values))
 
   def test_null(self):
     schema = GenericSchema({


### PR DESCRIPTION
I noticed that using `numpy.float64` (whose schema is set to `NUMBER`) as jubakit input cause UnicodeWarning.

I added test case to reproduce this issue (c2c1507).

```sh
$ git checkout c2c1507
$ python setup.py test --test-suite jubakit.test.test_base
```

```py
test_numpy (jubakit.test.test_base.GenericSchemaTest) ... /home/jubatus/Development/jubakit/jubakit/base.py:163: UnicodeWarning: Unicode unequal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if v != '':
ok
```

This is because we are comparing `numpy.float64` and `unicode` in `base.py`: https://github.com/jubatus/jubakit/blob/v0.2.1/jubakit/base.py#L163

This code aims to remove NAs (i.e., empty string in `NUMBER` column); it is working as expected but is better to remove warnings.