### PR TITLE
Fix CSVLoader to use specified parameter when estimating number of columns

### DIFF
--- a/jubakit/loader/csv.py
+++ b/jubakit/loader/csv.py
@@ -23,6 +23,11 @@ class CSVLoader(BaseLoader):
     specified as False, sequential column names are automatically generated
     like ['c0', 'c1', ...].  If `fieldnames` is a list, it is used as column
     names.
+
+    Any other optional or keyword arguments are passed to the underlying
+    `csv.DictReader`.
+
+    >>> loader = CSVLoader('dataset.tsv', fieldnames=False, encoding='cp932', delimiter='\t')
     """
 
     if fieldnames == True:
@@ -32,9 +37,10 @@ class CSVLoader(BaseLoader):
       # Generate field names by peeking number of columns in the first row
       # of the CSV.
       with io.open(filename, encoding=encoding, newline='') as f:
-        for ent in csv.reader(f):
-          fieldnames = ['c{0}'.format(i) for i in range(len(ent))]
-          break
+        # Use fieldnames from DictReader to count number of columns in the first row.
+        # We use csv.DictReader instead of plain csv.reader for compatibility of *args and **kwargs.
+        r = csv.DictReader(f, fieldnames=None, *args, **kwargs)
+        fieldnames = ['c{0}'.format(i) for i in range(len(r.fieldnames))]
 
     self._filename = filename
     self._fieldnames = fieldnames

--- a/jubakit/loader/csv.py
+++ b/jubakit/loader/csv.py
@@ -30,6 +30,18 @@ class CSVLoader(BaseLoader):
     >>> loader = CSVLoader('dataset.tsv', fieldnames=False, encoding='cp932', delimiter='\t')
     """
 
+    # Some dialect parameters must be encoded in unicode on Py3, whereas
+    # bytes on Py2.  We conceal such differences.
+    for cp in ['delimiter', 'escapechar', 'quotechar']:
+      if cp not in kwargs: break
+
+      v = kwargs[cp]
+      if PYTHON3 and isinstance(v, bytes):
+        v = v.decode(encoding)
+      elif not PYTHON3 and isinstance(v, unicode_t):
+        v = v.encode(encoding)
+      kwargs[cp] = v
+
     if fieldnames == True:
       # Automatically estimate field names later.
       fieldnames = None

--- a/jubakit/loader/csv.py
+++ b/jubakit/loader/csv.py
@@ -30,28 +30,14 @@ class CSVLoader(BaseLoader):
     >>> loader = CSVLoader('dataset.tsv', fieldnames=False, encoding='cp932', delimiter='\t')
     """
 
-    # Some dialect parameters must be encoded in unicode on Py3, whereas
-    # bytes on Py2.  We conceal such differences.
-    for cp in ['delimiter', 'escapechar', 'quotechar']:
-      if cp not in kwargs: break
-
-      v = kwargs[cp]
-      if PYTHON3 and isinstance(v, bytes):
-        v = v.decode(encoding)
-      elif not PYTHON3 and isinstance(v, unicode_t):
-        v = v.encode(encoding)
-      kwargs[cp] = v
-
     if fieldnames == True:
       # Automatically estimate field names later.
       fieldnames = None
     elif fieldnames == False:
-      # Generate field names by peeking number of columns in the first row
-      # of the CSV.
+      # Generate field names by peeking number of columns in the first row of the CSV.
       with io.open(filename, encoding=encoding, newline='') as f:
         # Use fieldnames from DictReader to count number of columns in the first row.
-        # We use csv.DictReader instead of plain csv.reader for compatibility of *args and **kwargs.
-        r = csv.DictReader(f, fieldnames=None, *args, **kwargs)
+        r = _UnicodeDictReader(f, encoding, fieldnames=None, *args, **kwargs)
         fieldnames = ['c{0}'.format(i) for i in range(len(r.fieldnames))]
 
     self._filename = filename
@@ -61,14 +47,44 @@ class CSVLoader(BaseLoader):
     self._kwargs = kwargs
 
   def rows(self):
-    def _encode_file(f, enc):
-      for line in f: yield line.encode(enc)
-    def _decode_row(r, enc):
-      return dict([(k.decode(enc), r[k].decode(enc)) for k in r.keys()])
-
     with io.open(self._filename, encoding=self._encoding, newline='') as f:
-      f = f if PYTHON3 else _encode_file(f, self._encoding)
-      reader = csv.DictReader(f, fieldnames=self._fieldnames, *self._args, **self._kwargs)
+      reader = _UnicodeDictReader(f, self._encoding, fieldnames=self._fieldnames, *self._args, **self._kwargs)
       for row in reader:
-        ent = row if PYTHON3 else _decode_row(row, self._encoding)
-        yield ent
+        yield row
+
+class _UnicodeDictReader(csv.DictReader):
+  def __init__(self, f, encoding, *args, **kwargs):
+    self._encoding = encoding
+
+    # DictReader in Python 2.x use str (bytes) for parameters, whereas Python 3.x use
+    # str (unicode) for them.  The code below is intended to absorbs the difference.
+    def convert(v):
+      if PYTHON3 and isinstance(v, bytes):
+        return v.decode(encoding)
+      elif not PYTHON3 and isinstance(v, unicode_t):
+        return v.encode(encoding)
+      return v
+
+    for k in ['delimiter', 'escapechar', 'quotechar', 'lineterminator', 'restkey', 'restval']:
+      if k in kwargs: kwargs[k] = convert(kwargs[k])
+
+    fieldnames = kwargs.get('fieldnames', None)
+    if fieldnames:
+      kwargs['fieldnames'] = list(map(lambda x: convert(x), fieldnames))
+
+    # DictReader in Python 2.x cannot handle Unicode input.
+    # We transcode each line of CSV row into bytes for Py2.
+    def encode_file(f):
+      for line in f:
+        yield line.encode(encoding)
+    f = f if PYTHON3 else encode_file(f)
+    csv.DictReader.__init__(self, f, *args, **kwargs)
+
+  def next(self):
+    r = csv.DictReader.next(self)
+    if PYTHON3:
+      return r
+    else:
+      # DictReader in Python 2.x returns rows in bytes.  We transcode keys/values of
+      # the row dict into Unicode like in Python 3.x.
+      return dict([(k.decode(self._encoding), r[k].decode(self._encoding)) for k in r.keys()])

--- a/jubakit/test/__init__.py
+++ b/jubakit/test/__init__.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 __all__ = ['requireSklearn']
 
+from jubakit.compat import PYTHON3
+
 try:
   import numpy
   import scipy
@@ -16,6 +18,10 @@ try:
   from unittest import skipUnless
   def requireSklearn(target):
     return skipUnless(sklearn_available, 'requires scikit-learn')(target)
+  def requirePython3(target):
+    return skipUnless(PYTHON3, 'requires Python 3.x')(target)
 except ImportError:
   def requireSklearn(target):
     return target if sklearn_available else None
+  def requirePython3(target):
+    return target if PYTHON3 else None

--- a/jubakit/test/loader/test_csv.py
+++ b/jubakit/test/loader/test_csv.py
@@ -7,6 +7,8 @@ from tempfile import NamedTemporaryFile as TempFile
 
 from jubakit.loader.csv import CSVLoader
 
+from .. import requirePython3
+
 class CSVLoaderTest(TestCase):
   def test_simple(self):
     with TempFile() as f:
@@ -63,4 +65,17 @@ class CSVLoaderTest(TestCase):
         lines += 1
         self.assertEqual('テスト1', row['v1'])
         self.assertEqual('テスト2', row['v2'])
+      self.assertEqual(1, lines)
+
+  @requirePython3
+  def test_unicode_separator(self):
+    with TempFile() as f:
+      f.write("v1★v2\ns1★s2\n".encode('utf-8'))
+      f.flush()
+      loader = CSVLoader(f.name, delimiter='★')
+      lines = 0
+      for row in loader:
+        lines += 1
+        self.assertEqual('s1', row['v1'])
+        self.assertEqual('s2', row['v2'])
       self.assertEqual(1, lines)

--- a/jubakit/test/loader/test_csv.py
+++ b/jubakit/test/loader/test_csv.py
@@ -13,7 +13,9 @@ class CSVLoaderTest(TestCase):
       f.write("k1,\"k2\",k3\n1,2,3\n4,5,6".encode('utf-8'))
       f.flush()
       loader = CSVLoader(f.name)
+      lines = 0
       for row in loader:
+        lines += 1
         self.assertEqual(set(['k1','k2','k3']), set(row.keys()))
         if row['k1'] == '1':
           self.assertEqual('2', row['k2'])
@@ -23,20 +25,23 @@ class CSVLoaderTest(TestCase):
           self.assertEqual('6', row['k3'])
         else:
           self.fail('unexpected row')
+      self.assertEqual(2, lines)
 
   def test_guess_header(self):
     with TempFile() as f:
-      f.write("k1,k2,k3\n1,2,3".encode())
+      f.write("k1|k2|k3\n1|2|3".encode())
       f.flush()
-      loader = CSVLoader(f.name, fieldnames=True)
+      loader = CSVLoader(f.name, fieldnames=True, delimiter='|')
       self.assertEqual([{'k1': '1', 'k2': '2', 'k3': '3'}], list(loader))
 
   def test_noheader(self):
     with TempFile() as f:
-      f.write("1,\"2\",3\n\"4\",5,\"6\"".encode('utf-8'))
+      f.write("1|\"2\"|3\n\"4\"|5|\"6\"".encode('utf-8'))
       f.flush()
-      loader = CSVLoader(f.name, False)
+      loader = CSVLoader(f.name, False, delimiter='|')
+      lines = 0
       for row in loader:
+        lines += 1
         self.assertEqual(set(['c0','c1','c2']), set(row.keys()))
         if row['c0'] == '1':
           self.assertEqual('2', row['c1'])
@@ -46,12 +51,16 @@ class CSVLoaderTest(TestCase):
           self.assertEqual('6', row['c2'])
         else:
           self.fail('unexpected row')
+      self.assertEqual(2, lines)
 
   def test_cp932(self):
     with TempFile() as f:
-      f.write("テスト1,テスト2".encode('cp932'))
+      f.write("v1,v2\nテスト1,テスト2\n".encode('cp932'))
       f.flush()
-      loader = CSVLoader(f.name, None, 'cp932')
+      loader = CSVLoader(f.name, None, 'cp932', delimiter=',')
+      lines = 0
       for row in loader:
-        self.assertEqual('テスト1', row['c0'])
-        self.assertEqual('テスト2', row['c1'])
+        lines += 1
+        self.assertEqual('テスト1', row['v1'])
+        self.assertEqual('テスト2', row['v2'])
+      self.assertEqual(1, lines)

--- a/jubakit/test/loader/test_csv.py
+++ b/jubakit/test/loader/test_csv.py
@@ -57,15 +57,42 @@ class CSVLoaderTest(TestCase):
 
   def test_cp932(self):
     with TempFile() as f:
-      f.write("v1,v2\nテスト1,テスト2\n".encode('cp932'))
+      f.write("列1,列2\nテスト1,テスト2\n".encode('cp932'))
       f.flush()
+      # predict field names from 1st row
       loader = CSVLoader(f.name, None, 'cp932', delimiter=',')
       lines = 0
       for row in loader:
         lines += 1
-        self.assertEqual('テスト1', row['v1'])
-        self.assertEqual('テスト2', row['v2'])
+        self.assertEqual('テスト1', row['列1'])
+        self.assertEqual('テスト2', row['列2'])
       self.assertEqual(1, lines)
+
+  def test_cp932_seq_fieldnames(self):
+    with TempFile() as f:
+      f.write("テスト1,テスト2\nテスト1,テスト2".encode('cp932'))
+      f.flush()
+      # assign sequential field names
+      loader = CSVLoader(f.name, False, 'cp932', delimiter=',')
+      lines = 0
+      for row in loader:
+        lines += 1
+        self.assertEqual('テスト1', row['c0'])
+        self.assertEqual('テスト2', row['c1'])
+      self.assertEqual(2, lines)
+
+  def test_cp932_manual_fieldnames(self):
+    with TempFile() as f:
+      f.write("テスト1,テスト2\nテスト1,テスト2".encode('cp932'))
+      f.flush()
+      # assign field names statically
+      loader = CSVLoader(f.name, ['列1', '列2'], 'cp932', delimiter=',')
+      lines = 0
+      for row in loader:
+        lines += 1
+        self.assertEqual('テスト1', row['列1'])
+        self.assertEqual('テスト2', row['列2'])
+      self.assertEqual(2, lines)
 
   @requirePython3
   def test_unicode_separator(self):


### PR DESCRIPTION
`CSVLoader` has a feature to automatically assign field names for each column ([c1, c2, c3, ...]) based on the number of columns in the first row of the CSV file.  However, specified constructor options (`*args` and `**kwargs`, in which users may specify delimiter, dialect, etc.) are not used when counting number of columns.  This PR fixes the problem.