### PR TITLE
Add jubash (#38)

### DIFF
--- a/jubakit/_cli/__init__.py
+++ b/jubakit/_cli/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from .service import *

--- a/jubakit/_cli/args.py
+++ b/jubakit/_cli/args.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+
+"""
+Classes for command line argument type validation.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import inspect
+
+from jubatus.common import Datum
+
+from ..compat import shell_split
+
+class Rule(object):
+  def convert(self, args):
+    raise NotImplementedError
+
+  def min_max(self):
+    raise NotImplementedError
+
+class Type(Rule): pass
+
+class Requirement(Rule): pass
+
+class Mandatory(Requirement):
+  def __init__(self, t):
+    self.t = t
+
+  def convert(self, args):
+    if issubclass(self.t, Type):
+      return self.t().convert(args)
+    else:
+      return (1, self.t(args[0]))
+
+  def min_max(self):
+    if issubclass(self.t, Type):
+      return self.t().min_max()
+    else:
+      return (1, 1)
+
+class Optional(Mandatory):
+  def convert(self, args):
+    if len(args) == 0:
+      return (0, None)
+    return super(Optional, self).convert(args)
+
+  def min_max(self):
+    return (0, super(Optional, self).min_max()[1])
+
+def Arguments(*expected_types):
+  def wrap_by_preprocessor(func):
+    assert len(inspect.getargspec(func).args) == (len(expected_types) + 1)
+
+    def preprocessor(self, line):
+      params = shell_split(line)
+      types = []
+      (min_count, max_count) = (0, 0)
+
+      for t in expected_types:
+        if not isinstance(t, Requirement):
+          t = Mandatory(t)
+        types.append(t)
+        (t_min, t_max) = t.min_max()
+        min_count += t_min
+        if t_max is None:
+          max_count = None
+        elif max_count is not None:
+          max_count += t_max
+
+      params_len = len(params)
+      if params_len < min_count:
+        raise ValueError('Too few arguments ({0} required at least, only got {1})'.format(min_count, params_len))
+      if max_count is not None and max_count < params_len:
+        raise ValueError('Too many arguments ({0} required at most, got {1})'.format(max_count, params_len))
+
+      index = 0
+      argv = []
+      for t in types:
+        try:
+          (consumed, value) = t.convert(params[index:])
+        except ValueError as e:
+          raise ValueError('argument {0}: {1}'.format(index + 1, e))
+        argv.append(value)
+        index += consumed
+      return func(self, *argv)
+    preprocessor.__doc__ = func.__doc__
+    return preprocessor
+  return wrap_by_preprocessor
+
+class TProperty(Type):
+  def convert(self, args):
+    if len(args)  % 2 != 0:
+      raise ValueError('value for the last property key ({0}) is missing'.format(args[len(args) - 1]))
+    p = {}
+    for i in range(int(len(args) / 2)):
+      p[args[i*2]] = args[i*2+1]
+    return (len(args), p)
+
+  def min_max(self):
+    return (2, None)
+
+class TDatum(Type):
+  def convert(self, args):
+    if len(args) % 2 != 0:
+      raise ValueError('value for the last datum key ({0}) is missing'.format(args[len(args) - 1]))
+
+    d = Datum()
+    for i in range(int(len(args) / 2)):
+      feat_key = args[i*2]
+      feat_val = args[i*2+1]
+      try:
+        d.add_number(feat_key, float(feat_val))
+      except ValueError:
+        d.add_string(feat_key, feat_val)
+    return (len(args), d)
+
+  def min_max(self):
+    return (0, None)
+
+def TMultiDatum(count):
+  class TOffsetDatum(TDatum):
+    def convert(self, args):
+      if '|' not in args:
+        raise ValueError('insufficient number of datum')
+      (consumed, value) = super(TOffsetDatum, self).convert(args[:args.index('|')])
+      return (consumed + 1, value)
+
+    def min_max(self):
+      return (1, None)
+
+  return [TOffsetDatum] * (count - 1) + [TDatum]

--- a/jubakit/_cli/base.py
+++ b/jubakit/_cli/base.py
@@ -1,0 +1,176 @@
+# -*- ncoding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import subprocess
+
+from .util import print
+from .cmd import ExtendedCmd
+from .args import Arguments, Optional
+
+class BaseCLI(ExtendedCmd):
+  """
+  A base class for CLI interface of all services.
+  """
+
+  def __init__(self, shell, *args, **kwargs):
+    super(BaseCLI, self).__init__(*args, **kwargs)
+
+    self._sh = shell
+
+    # Set help sentences.
+    self.doc_header = "Commands:"
+    self.undoc_header = "Commands (no help available):"
+    self.misc_header = "Documents:"
+    self.nohelp = "No help available for %s."
+
+    # Register aliases.
+    self.register_alias('EOF', 'do_exit')
+    self.register_alias('ls', 'do_help')
+    self.register_alias('shell', 'shell_command')
+
+  #################################################################
+  # Override methods to tweak CLI behavior
+  #################################################################
+
+  def emptyline(self):
+    """
+    By default, empty line causes the previous command to run again.
+    This overrides the default handler for emptyline so it behaves like an usual shell.
+    """
+    pass
+
+  def postcmd(self, stop, line):
+    """
+    After a single command is executed, we discard the connection if not in
+    keepalive mode.
+    """
+    if not self._sh._keepalive:
+      self._sh.disconnect()
+      self._sh.connect()
+    return stop
+
+  def default(self, line):
+    """
+    Raise exception for unhandled commands.
+    """
+    raise CLIUnknownCommandException(line)
+
+  #################################################################
+  # Common interfaces for Jubatus CLI
+  #################################################################
+
+  @classmethod
+  def _name(cls):
+    """
+    Returns the name of the service (e.g., `classifier`).
+    You must override this in subclasses.
+    """
+    raise NotImplementedError
+
+  def _verbose(self, msg):
+    """
+    Outputs logs only when in verbose mode.
+    """
+    if self._sh._verbose:
+      print(msg)
+
+  @property
+  def client(self):
+    """
+    Returns the client instance.
+    """
+    return self._sh.get_client()
+
+  #################################################################
+  # Built-in shell commands
+  #################################################################
+
+  @Arguments()
+  def do_exit(self):
+    """Syntax: exit
+    Exits the shell.  You can also use EOF (Ctrl-D).
+    """
+    print()
+    return True
+
+  def help_help(self):
+    print(
+    """Syntax: help [command]
+    Displays the list of commands available.
+    If ``command`` is specified, displays the help for the command."""
+    )
+
+  def shell_command(self, param):
+    """
+    Runs the command in the *real* shell.
+    """
+    subprocess.call(param, shell=True)
+
+class CLIInvalidatedException(Exception):
+  """
+  Notify Shell to regenerate CLI instance.
+  """
+  pass
+
+class CLIUnknownCommandException(Exception):
+  """
+  Notify Shell that unknown command is specified.
+  """
+  pass
+
+class BaseRpcCLI(BaseCLI):
+  """
+  CLI that supports RPC commands.
+  """
+
+  @Arguments(str, int, Optional(str))
+  def do_connect(self, host, port, cluster):
+    """Syntax: connect host port [cluster]
+    Connect to the specified host, port and cluster (optional).
+    """
+    if cluster is None:
+      cluster = self._sh._cluster
+
+    print("Connecting to <{0}>@{1}:{2}...".format(cluster, host, port))
+    self._sh.set_remote(host, port, cluster, None)
+    raise CLIInvalidatedException()
+
+  @Arguments()
+  def do_reconnect(self):
+    """Syntax: reconnect
+    Reconnects to the current server.
+    """
+    self._sh.connect()
+    raise CLIInvalidatedException()
+
+  @Arguments()
+  def do_verbose(self):
+    """Syntax: verbose
+    Toggles the verbose mode.
+    """
+    self._sh._verbose = not self._sh._verbose
+    if self._sh._verbose:
+      print("Verbose mode: on")
+    else:
+      print("Verbose mode: off")
+
+  @Arguments()
+  def do_keepalive(self):
+    """Syntax: keepalive
+    Toggles the keepalive mode.
+    """
+    self._sh._keepalive = not self._sh._keepalive
+    if self._sh._keepalive:
+      print("Keepalive: enabled")
+    else:
+      print("Keepalive: disabled")
+
+  @Arguments(Optional(int))
+  def do_timeout(self, timeout):
+    """Syntax: timeout [new_value]
+    Displays or sets the client-side timeout.
+    """
+    if timeout is not None:
+      self._sh.set_timeout(timeout)
+    print("Timeout: {0} seconds".format(self._sh.get_timeout()))

--- a/jubakit/_cli/cmd.py
+++ b/jubakit/_cli/cmd.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import cmd
+
+class ExtendedCmd(cmd.Cmd, object):
+  """
+  Extended framework of standard cmd.Cmd class with better completion
+  support and alias features.
+  """
+
+  def parseline(self, line):
+    line = line.strip()
+    if not line:
+      return None, None, line
+    elif line[0] == '?':
+      line = 'help ' + line[1:]
+    elif line[0] == '!':
+      if hasattr(self, 'do_shell'):
+        line = 'shell ' + line[1:]
+      else:
+        return None, None, line
+    i, n = 0, len(line)
+    while i < n and line[i] in self.identchars: i = i+1
+    cmd, arg = line[:i], line[i:].strip()
+    return cmd, arg, line
+
+  def complete(self, text, state):
+    result = super(ExtendedCmd, self).complete(text, state)
+    if len(self.completion_matches) == 1:
+      return self.completion_matches[state] + ' ' if state == 0 else None
+    return result
+
+  def register_alias(self, alias, name):
+    """
+    Register alias function to the method.
+    Aliases are not listed by `help` command.
+    """
+    self.__dict__['do_' + alias] = getattr(self, name)

--- a/jubakit/_cli/service/__init__.py
+++ b/jubakit/_cli/service/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from .generic import *
+
+from .anomaly import *
+from .bandit import *
+from .burst import *
+from .classifier import *
+from .clustering import *
+from .graph import *
+from .nearest_neighbor import *
+from .recommender import *
+from .regression import *
+from .stat import *
+from .weight import *

--- a/jubakit/_cli/service/anomaly.py
+++ b/jubakit/_cli/service/anomaly.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.anomaly.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments, TDatum
+from ..util import *
+
+class AnomalyCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'anomaly'
+
+  @Arguments(str)
+  def do_clear_row(self, row_id):
+    """Syntax: clear_row row_id
+    Clear the specified row.
+    """
+    result = self.client.clear_row(row_id)
+    if not result:
+      print("Failed")
+
+  @Arguments(TDatum)
+  def do_add(self, d):
+    """Syntax: add datum_key datum_value [datum_key datum_value ...]
+    Add a point.
+    """
+    self._verbose('datum = {0}'.format(d))
+    point = self.client.add(d)
+    print("Row ID: {0}".format(point.id))
+    print("Score: {0}".format(point.score))
+
+  @Arguments(str, TDatum)
+  def do_update(self, row_id, d):
+    """Syntax: update row_id datum_key datum_value [datum_key datum_value ...]
+    Update a point.
+    """
+    self._verbose('datum = {0}'.format(d))
+    score = self.client.update(row_id, d)
+    print("Score: {0}".format(score))
+
+  @Arguments(str, TDatum)
+  def do_overwrite(self, row_id, d):
+    """Syntax: overwrite row_id datum_key datum_value [datum_key datum_value ...]
+    Overwrite the point.
+    """
+    self._verbose('datum = {0}'.format(d))
+    score = self.client.overwrite(row_id, d)
+    print("Score: {0}".format(score))
+
+  @Arguments(TDatum)
+  def do_calc_score(self, d):
+    """Syntax: calc_score datum_key datum_value [datum_key datum_value ...]
+    Calculate an anomaly measure value without adding a point.
+    """
+    self._verbose('datum = {0}'.format(d))
+    score = self.client.calc_score(d)
+    print("Score: {0}".format(score))
+
+  @Arguments()
+  def do_get_all_rows(self):
+    """Syntax: get_all_rows
+    Returns all rows. Note that converted rows will not be displayed.
+    """
+    rows = self.client.get_all_rows()
+    for row in rows:
+      print(row)

--- a/jubakit/_cli/service/bandit.py
+++ b/jubakit/_cli/service/bandit.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.bandit.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments
+from ..util import *
+
+class BanditCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'bandit'
+
+  @Arguments(str)
+  def do_register_arm(self, arm_id):
+    """Syntax: register_arm arm_id
+    Adds the specified arm.
+    """
+    self.client.register_arm(arm_id)
+
+  @Arguments(str)
+  def do_delete_arm(self, arm_id):
+    """Syntax: delete_arm arm_id
+    Deletes the specified arm.
+    """
+    self.client.delete_arm(arm_id)
+
+  @Arguments(str)
+  def do_select_arm(self, player_id):
+    """Syntax: select_arm player_id
+    Select the specified arm and return the next best guess.
+    """
+    print(self.client.select_arm(player_id))
+
+  @Arguments(str, str, float)
+  def do_register_reward(self, player_id, arm_id, reward):
+    """Syntax: register_reward player_id arm_id reward
+    Registers the reward for the specified player and ID.
+    """
+    print(self.client.register_reward(player_id, arm_id, reward))
+
+  @Arguments(str)
+  def do_get_arm_info(self, player_id):
+    """Syntax: get_arm_info player_id
+    Returns the arm info for the specified ID.
+    """
+    print(self.client.get_arm_info(player_id))
+
+  @Arguments(str)
+  def do_reset(self, player_id):
+    """Syntax: reset player_id
+    Resets the specified player record.
+    """
+    print(self.client.reset(player_id))

--- a/jubakit/_cli/service/burst.py
+++ b/jubakit/_cli/service/burst.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import time
+
+from jubatus.burst.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments, Optional
+from ..util import *
+
+class BurstCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'burst'
+
+  def _clear_cache(self):
+    self._cached_keywords = set()
+
+  def _print_window(self, kwd, w):
+    print("Keyword: {0}".format(kwd))
+    print("  Starting Position: {0}".format(w.start_pos))
+    print("  Batches:")
+    for bat in w.batches:
+      print("  all_data_count = {0}, relevant_data_count = {1}, burst_weight = {2}".format(bat.all_data_count, bat.relevant_data_count, bat.burst_weight))
+
+  @Arguments(str, Optional(float))
+  def do_add_document(self, text, pos):
+    """Syntax: add_document text [position]
+    Adds a new document (text).
+    When position is omitted, epoch time will be used.
+    Bulk request (add_documents) is not supported on the command line.
+    """
+    if pos is None:
+      pos = float(time.time())
+    result = self.client.add_documents([Document(pos, text)])
+    self._verbose("Position: {0}".format(pos))
+    if result != 1:
+      print("Failed; maybe the position is out-dated?")
+
+  @Arguments(str, Optional(float))
+  def do_get_result(self, keyword, pos):
+    """Syntax: get_result keyword [position]
+    Get the result of burst detection for the given keyword.
+    When position is specified, get_result_at API will be called.
+    Otherwise the latest result will be retrieved via get_result API.
+    """
+    if pos is None:
+      result = self.client.get_result(keyword)
+    else:
+      result = self.client.get_result_at(keyword, pos)
+    self._print_window(keyword, result)
+
+  @Arguments(Optional(float))
+  def do_get_all_bursted_results(self, pos):
+    """Syntax: get_all_bursted_results keyword [position]
+    Get the result of burst detection for all keywords.
+    When position is specified, get_all_bursted_results_at API will be called.
+    Otherwise the latest result will be retrieved via get_all_bursted_results API.
+    """
+    if pos is None:
+      result = self.client.get_all_bursted_results()
+    else:
+      result = self.client.get_all_bursted_results_at(pos)
+    for kwd in result:
+      self._cached_keywords.add(kwd)
+      self._print_window(kwd, result[kwd])
+
+  @Arguments()
+  def do_get_all_keywords(self):
+    """Syntax get_all_keywords
+    Prints all keywords and their parameters.
+    """
+    result = self.client.get_all_keywords()
+    self._cached_keywords.clear()
+    self._cached_keywords.update([x.keyword for x in result])
+    for kwd in result:
+      print("Keyword: {0}".format(kwd.keyword))
+      print("  Scaling Parameter: {0}".format(kwd.scaling_param))
+      print("  Gamma: {0}".format(kwd.gamma))
+
+  @Arguments(str, Optional(float), Optional(float))
+  def do_add_keyword(self, keyword, scaling_param, gamma):
+    """Syntax: add_keyword keyword [scaling_param [gamma]]
+    Adds the keyword for burst detection.
+    scaling_param and gamma are optional; 2.0 and 1.0 is used when ommitted.
+    """
+    if scaling_param is None:
+      scaling_param = 2.0
+    if gamma is None:
+      gamma = 1.0
+    result = self.client.add_keyword(KeywordWithParams(keyword, scaling_param, gamma))
+    self._cached_keywords.add(keyword)
+    if not result:
+      print("Failed; maybe the keyword is already registered?")
+
+  @Arguments(str)
+  def do_remove_keyword(self, keyword):
+    """Syntax: remove_keyword keyword
+    Removes the specified keyword.
+    """
+    result = self.client.remove_keyword(keyword)
+    self._cached_keywords.discard(keyword)
+    if not result:
+      print("Failed; maybe the keyword does not exist on the server?")
+
+  @Arguments()
+  def do_remove_all_keywords(self):
+    """Syntax: remove_all_keywords
+    Removes all keywords.
+    """
+    result = self.client.remove_all_keywords()
+    self._cached_keywords.clear()
+    if not result:
+      print("Failed")

--- a/jubakit/_cli/service/classifier.py
+++ b/jubakit/_cli/service/classifier.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.classifier.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments, TDatum
+from ..util import *
+
+class ClassifierCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'classifier'
+
+  def _clear_cache(self):
+    self._labels = set()
+
+  @Arguments(str, TDatum)
+  def do_train(self, label, d):
+    """Syntax: train label datum_key datum_value [datum_key datum_value ...]
+    Trains the model with given label and datum.
+    Bulk training is not supported on the command line.
+    """
+    self._verbose("datum = {0}".format(d))
+    result = self.client.train([LabeledDatum(label, d)])
+    if result != 1:
+      print("Failed")
+    self._labels.add(label)
+
+  def complete_train(self, text, line, begidx, endidx):
+    pos = comp_position(text, line, begidx, endidx)
+    if pos == 0:
+      return filter_candidates(text, self._labels)
+
+  @Arguments(TDatum)
+  def do_classify(self, d):
+    """Syntax: classify datum_key datum_value [datum_key datum_value ...]
+    Classify the given datum.
+    Bulk classification is not supported on the command line.
+    """
+    self._verbose("datum = {0}".format(d))
+    results = self.client.classify([d])[0]
+    results.sort(key=lambda e: e.score, reverse=True)
+    for result in results:
+      print("{0}: {1}".format(result.label, str(result.score)))
+      self._labels.add(result.label)
+
+  @Arguments()
+  def do_get_labels(self):
+    """Syntax: get_labels
+    Prints the list of currently registered labels and number of instances trained for each label.
+    """
+    labels = self.client.get_labels()
+    for (label, count) in labels.items():
+      print('{0}: {1}'.format(label, count))
+    self._labels = set(labels.keys())
+
+  @Arguments(str)
+  def do_set_label(self, label):
+    """Syntax: set_label label
+    Registers the new label without training.
+    """
+    result = self.client.set_label(label)
+    if not result:
+      print("Failed")
+    self._labels.add(label)
+
+  @Arguments(str)
+  def do_delete_label(self, label):
+    """Syntax: delete_label label
+    Deletes the label.
+    """
+    result = self.client.delete_label(label)
+    if not result:
+      print("Failed")
+    self._labels.discard(label)

--- a/jubakit/_cli/service/clustering.py
+++ b/jubakit/_cli/service/clustering.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.clustering.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments, TDatum
+from ..util import *
+
+class ClusteringCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'clustering'
+
+  @Arguments(TDatum)
+  def do_push(self, d):
+    """Syntax: push datum_key datum_value [...]
+    Add a point. Bulk request is not supported.
+    """
+    self._verbose("datum = {0}".format(d))
+    if not self.client.push([d]):
+      print("Failed")
+
+  @Arguments()
+  def do_get_revision(self):
+    """Syntax: get_revision
+    Return the revision of the cluster.
+    """
+    print(self.client.get_revision())
+
+  @Arguments()
+  def do_get_core_members(self):
+    """Syntax: get_core_members
+    Return the coreset of the cluster.
+    """
+    result = self.client.get_core_members()
+    for cluster in result:
+      print("[Cluster]")
+      for member in cluster:
+        print("  Datum: {0}".format(member.point))
+        print("  (weight: {0})".format(member.weight))
+
+  @Arguments()
+  def do_get_k_center(self):
+    """Syntax: get_k_center
+    Returns k cluster centers.
+    """
+    result = self.client.get_k_center()
+    for cluster in result:
+      print("[Cluster]")
+      print("  Datum: {0}".format(cluster))
+
+  @Arguments(TDatum)
+  def do_get_nearest_center(self, d):
+    """Syntax: get_nearest_center datum_key datum_value [...]
+    Returns nearest cluster center without adding point to cluster.
+    """
+    self._verbose("datum = {0}".format(d))
+    result = self.client.get_nearest_center(d)
+    print(result)
+
+  @Arguments(TDatum)
+  def do_get_nearest_members(self, d):
+    """Syntax: get_nearest_members datum_key datum_value [...]
+    Returns nearest summary of cluster(coreset) from point.
+    """
+    self._verbose("datum = {0}".format(d))
+    result = self.client.get_nearest_members(d)
+    for member in result:
+      print("Datum: {0}".format(member.point))
+      print("(weight: {0})".format(member.weight))

--- a/jubakit/_cli/service/generic.py
+++ b/jubakit/_cli/service/generic.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+
+from ..base import BaseRpcCLI
+from ..args import Arguments
+from ..util import *
+
+class GenericCLI(BaseRpcCLI):
+  """
+  Base CLI implementation for all other services.
+  """
+
+  def __init__(self, *args, **kwargs):
+    super(GenericCLI, self).__init__(*args, **kwargs)
+    self._clear_cache()
+
+  @classmethod
+  def _name(cls):
+    return 'generic'
+
+  def _clear_cache(self):
+    """
+    Subclasses using cache must override this method; initialize or invalidate
+    cache when this method is called.
+    """
+    pass
+
+  def _print_status(self, status):
+    """
+    Pretty-print the status structure.
+    """
+    for (host_port, status) in status.items():
+      print("Server {0}:{1}".format(*(host_port.split('_'))))
+      for key in sorted(status.keys()):
+        print("  {0}: {1}".format(key, status[key]))
+
+  @Arguments()
+  def do_get_config(self):
+    """Syntax: get_config
+    Display algorithm and converter configuration set in server.
+    """
+    config = self.client.get_config()
+    print(json.dumps(json.loads(config), sort_keys=True, indent=4))
+
+  @Arguments(str)
+  def do_save(self, model_id):
+    """Syntax: save model_id
+    Save the model.
+    """
+    result = self.client.save(model_id)
+    if result:
+      for (server_id, path) in result.items():
+        print("{0}:\t{1}".format(server_id, path))
+    else:
+      print("Failed")
+
+  @Arguments()
+  def do_clear(self):
+    """Syntax: clear
+    Clear the model.
+    """
+    result = self.client.clear()
+    if not result:
+      print("Failed")
+    self._clear_cache()
+
+  @Arguments(str)
+  def do_load(self, model_id):
+    """Syntax: load model_id
+    Load the given model.
+    """
+    result = self.client.load(model_id)
+    if not result:
+      print("Failed")
+
+  @Arguments()
+  def do_get_status(self):
+    """Syntax: get_status
+    Displays status of servers.
+    """
+    status = self.client.get_status()
+    self._print_status(status)
+
+  @Arguments()
+  def do_get_proxy_status(self):
+    """Syntax: get_proxy_status
+    Displays status of the proxy.
+    Available only when connected to proxies.
+    """
+    status = self.client.get_proxy_status()
+    self._print_status(status)
+
+  @Arguments()
+  def do_do_mix(self):
+    """Syntax: do_mix
+    Trigger MIX.
+    Available only when connected to servers.
+    """
+    result = self.client.do_mix()
+    if not result:
+      print("Failed")

--- a/jubakit/_cli/service/graph.py
+++ b/jubakit/_cli/service/graph.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.graph.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments, Optional, TProperty
+from ..util import *
+
+class GraphCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'graph'
+
+  @Arguments()
+  def do_create_node(self):
+    """Syntax: create_node
+    Create node.
+    """
+    result = self.client.create_node()
+    print(result)
+
+  @Arguments(str)
+  def do_remove_node(self, node_id):
+    """Syntax: remove_node node_id
+    Remove the specified node.
+    """
+    result = self.client.remove_node(node_id)
+    if not result:
+      print("Failed")
+
+  @Arguments(str, TProperty)
+  def do_update_node(self, node_id, prop):
+    """Syntax: update_node node_id [property_key property_value ...]
+    Update node.
+    """
+    result = self.client.update_node(node_id, prop)
+    if not result:
+      print("Failed")
+
+  @Arguments(str, str, Optional(TProperty))
+  def do_create_edge(self, from_node_id, to_node_id, prop):
+    """Syntax: create_edge from_node to_node [property_key property_value ...]
+    Create edge.
+    """
+    if prop is None:
+      prop = {}
+    info = Edge(prop, from_node_id, to_node_id)
+    result = self.client.create_edge(from_node_id, info)
+    print("Edge ID: {0}".format(result))
+
+  @Arguments(int, str, str, Optional(TProperty))
+  def do_update_edge(self, edge_id, from_node_id, to_node_id, prop):
+    """Syntax: update_edge edge_id from_node to_node [property_key property_value ...]
+    Update edge.
+    """
+    if prop is None:
+      prop = {}
+    info = Edge(prop, from_node_id, to_node_id)
+    result = self.client.update_edge(from_node_id, edge_id, info)
+    if not result:
+      print("Failed")
+
+  @Arguments(int, Optional(str))
+  def do_remove_edge(self, edge_id, from_node_id):
+    """Syntax: remove_edge edge_id [from_node]
+    Remove the specified edge.
+    from_node is mandatory when in distributed mode.
+    """
+    if from_node_id is None:
+      from_node_id = ""
+    result = self.client.remove_edge(from_node_id, edge_id)
+    if not result:
+      print("Failed")
+
+  @Arguments(str, Optional(int))
+  def do_get_centrality(self, node_id, c_type):
+    """Syntax: get_centrality node_id [type]
+    Calculate centrality for the node.
+    "type" is 0 (PageRank) by default.
+    Currenetly, only empty query is supported.
+    """
+    if c_type is None:
+      c_type = 0
+    query = PresetQuery([], [])
+    centrality = self.client.get_centrality(node_id, c_type, query)
+    print(centrality)
+
+  @Arguments()
+  def do_add_centrality_query(self):
+    """Syntax: add_centrality_query
+    Preset centrality query.
+    Currenetly, only empty query is supported.
+    """
+    query = PresetQuery([], [])
+    result = self.client.add_centrality_query(query)
+    if not result:
+      print("Failed")
+
+  @Arguments()
+  def do_add_shortest_path_query(self):
+    """Syntax: add_shortest_path_query
+    Preset shortest_path query.
+    Currenetly, only empty query is supported.
+    """
+    query = PresetQuery([], [])
+    result = self.client.add_shortest_path_query(query)
+    if not result:
+      print("Failed")
+
+  @Arguments()
+  def do_remove_centrality_query(self):
+    """Syntax: remove_centrality_query
+    Remove preset centrality query.
+    Currenetly, only empty query is supported.
+    """
+    query = PresetQuery([], [])
+    result = self.client.remove_centrality_query(query)
+    if not result:
+      print("Failed")
+
+  @Arguments()
+  def do_remove_shortest_path_query(self):
+    """Syntax: remove_shortest_path_query
+    Remove preset shortest_path query.
+    Currenetly, only empty query is supported.
+    """
+    query = PresetQuery([], [])
+    result = self.client.remove_shortest_path_query(query)
+    if not result:
+      print("Failed")
+
+  @Arguments(str, str, Optional(int))
+  def do_get_shortest_path(self, src_node, dst_node, max_hop):
+    """Syntax: get_shortest_path src_node dst_node [max_hop]
+    Calculates the shortest path from src_node to dst_node.
+    """
+    if max_hop is None:
+      max_hop = pow(2, 32) - 1
+    query = PresetQuery([], [])
+    req = ShortestPathQuery(src_node, dst_node, max_hop, query)
+    nodes = self.client.get_shortest_path(req)
+    for node in nodes:
+      print(node)
+
+  @Arguments()
+  def do_update_index(self):
+    """Syntax: update_index
+    Updates the index.
+    You cannot use this method in distributed configuration.
+    """
+    result = self.client.update_index()
+    if not result:
+      print("Failed")
+
+  @Arguments(str)
+  def do_get_node(self, node_id):
+    """Syntax: get_node node_id
+    Get node information.
+    """
+    info = self.client.get_node(node_id)
+    print("Properties:")
+    for key in info.property:
+      print("  {0}: {1}".format(key, info.property[key]))
+    print("In-Edges:")
+    print("  {0}".format(str(info.in_edges)))
+    print("Out-Edges:")
+    print("  {0}".format(str(info.out_edges)))
+
+  @Arguments(int, Optional(str))
+  def do_get_edge(self, edge_id, from_node_id):
+    """Syntax: get_edge edge_id [from_node_id]
+    Get edge information.
+    from_node_id is mandatory when in distributed mode.
+    """
+    if from_node_id is None:
+      from_node_id = "0"
+    info = self.client.get_edge(from_node_id, edge_id)
+    print("Properties:")
+    for key in info.property:
+      print("  {0}: {1}".format(key, info.property[key]))
+    print("Source     : {0}".format(info.source))
+    print("Destination: {0}".format(info.target))

--- a/jubakit/_cli/service/nearest_neighbor.py
+++ b/jubakit/_cli/service/nearest_neighbor.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.nearest_neighbor.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments, Optional, TDatum
+from ..util import *
+
+class NearestNeighborCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'nearest_neighbor'
+
+  def _clear_cache(self):
+    self._max_results = 100
+
+  def _print_id_with_scores(self, result):
+    for ent in result:
+      print("{0:<15} {1:>}".format(ent.score, ent.id))
+
+  @Arguments(str, TDatum)
+  def do_set_row(self, row_id, d):
+    """Syntax: set_row row_id datum_key datum_value [...]
+    Updates the row whose id is row_id with given datum.
+    """
+    self._verbose("datum = {0}".format(d))
+    result = self.client.set_row(row_id, d)
+    if not result:
+      print("Failed")
+
+  @Arguments(str)
+  def do_neighbor_row_from_id(self, row_id):
+    """Syntax: neighbor_row_from_id row_id
+    Get rows that have most similar datum to the given row ID.
+    """
+    result = self.client.neighbor_row_from_id(row_id, self._max_results)
+    self._print_id_with_scores(result)
+
+  @Arguments(TDatum)
+  def do_neighbor_row_from_datum(self, d):
+    """Syntax: neighbor_row_from_datum datum_key datum_value [...]
+    Get rows that have most similar datum to the given datum.
+    """
+    self._verbose("datum = {0}".format(d))
+    result = self.client.neighbor_row_from_datum(d, self._max_results)
+    self._print_id_with_scores(result)
+
+  @Arguments(str)
+  def do_similar_row_from_id(self, row_id):
+    """Syntax: similar_row_from_id row_id
+    Get rows that have most similar datum to the given row ID.
+    """
+    result = self.client.similar_row_from_id(row_id, self._max_results)
+    self._print_id_with_scores(result)
+
+  @Arguments(TDatum)
+  def do_similar_row_from_datum(self, d):
+    """Syntax: similar_row_from_datum datum_key datum_value [...]
+    Get rows that have most similar datum to the given datum.
+    """
+    self._verbose("datum = {0}".format(d))
+    result = self.client.similar_row_from_datum(d, self._max_results)
+    self._print_id_with_scores(result)
+
+  @Arguments()
+  def do_get_all_rows(self):
+    """Syntax: get_all_rows
+    Returns all rows. Note that converted rows will not be displayed.
+    """
+    rows = self.client.get_all_rows()
+    for row in rows:
+      print(row)
+
+  @Arguments(Optional(int))
+  def do_max_results(self, new_value):
+    """Syntax: max_results [new_value]
+    Displays or changes the maximum number of results for {neighbor,similar}_row_from_{id,data}.
+    """
+    if new_value is None:
+      print(self._max_results)
+    else:
+      self._max_results = new_value

--- a/jubakit/_cli/service/recommender.py
+++ b/jubakit/_cli/service/recommender.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.recommender.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments, Optional, TDatum, TMultiDatum
+from ..util import *
+
+class RecommenderCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'recommender'
+
+  def _clear_cache(self):
+    self._max_results = 100
+
+  def _print_similar_result(self, results):
+    results.sort(key=lambda e: e.score, reverse=True)
+    for result in results:
+      print("{0}: {1}".format(result.id, result.score))
+
+  @Arguments(str)
+  def do_clear_row(self, row_id):
+    """Syntax: clear_row row_id
+    Clear the specified row.
+    """
+    result = self.client.clear_row(row_id)
+    if not result:
+      print("Failed")
+
+  @Arguments(str, TDatum)
+  def do_update_row(self, row_id, d):
+    """Syntax: update_row row_id datum_key datum_value [datum_key datum_value ...]
+    Update or insert a new row.
+    """
+    self._verbose("datum = {0}".format(d))
+    result = self.client.update_row(row_id, d)
+    if not result:
+      print("Failed")
+
+  @Arguments(str)
+  def do_complete_row_from_id(self, row_id):
+    """Syntax: complete_row_from_id id
+    Complete row from the given ID.
+    """
+    d = self.client.complete_row_from_id(row_id)
+    print(d)
+
+  @Arguments(TDatum)
+  def do_complete_row_from_datum(self, d):
+    """syntax: complete_row_from_datum datum_key datum_value [datum_key datum_value ...]
+    Complete row from the given datum.
+    """
+    self._verbose("datum = {0}".format(d))
+    d = self.client.complete_row_from_datum(d)
+    print(d)
+
+  @Arguments(str)
+  def do_similar_row_from_id(self, row_id):
+    """Syntax: similar_row_from_id id
+    Similar row from the given ID.
+    """
+    results = self.client.similar_row_from_id(row_id, self._max_results)
+    self._print_similar_result(results)
+
+  @Arguments(TDatum)
+  def do_similar_row_from_datum(self, d):
+    """syntax: similar_row_from_datum datum_key datum_value [datum_key datum_value ...]
+    Similar row from the given datum.
+    """
+    results = self.client.similar_row_from_datum(d, self._max_results)
+    self._print_similar_result(results)
+
+  @Arguments(str)
+  def do_decode_row(self, row_id):
+    """Syntax: decode_row id
+    Decode the row of given ID.
+    """
+    d = self.client.decode_row(row_id)
+    print(d)
+
+  @Arguments()
+  def do_get_all_rows(self):
+    """Syntax: get_all_rows
+    Returns all rows. Note that converted rows will not be displayed.
+    """
+    rows = self.client.get_all_rows()
+    for row in rows:
+      print(row)
+
+  @Arguments(*TMultiDatum(2))
+  def do_calc_similarity(self, lhs, rhs):
+    """Syntax: calc_similarity datum1_key datum1_value ... | datum2_key datum2_value ...
+    Calculates similarity between two datum.
+    Separate two datum records with a bar ('|').
+    """
+    self._verbose("datum(lhs) = {0}".format(lhs))
+    self._verbose("datum(rhs) = {0}".format(rhs))
+    similarity = self.client.calc_similarity(lhs, rhs)
+    print(similarity)
+
+  @Arguments(TDatum)
+  def do_calc_l2norm(self, d):
+    """Syntax: calc_l2norm datum_key datum_value ...
+    Calculates L2 norm for the given datum.
+    """
+    self._verbose("datum = {0}".format(d))
+    l2norm = self.client.calc_l2norm(d)
+    print(l2norm)
+
+  @Arguments(Optional(int))
+  def do_max_results(self, new_value):
+    """Syntax: max_results [new_value]
+    Displays or changes the maximum number of results for similar_row_from_{id,datum}.
+    """
+    if new_value is None:
+      print(self._max_results)
+    else:
+      self._max_results = new_value

--- a/jubakit/_cli/service/regression.py
+++ b/jubakit/_cli/service/regression.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.regression.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments, TDatum
+from ..util import *
+
+class RegressionCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'regression'
+
+  @Arguments(float, TDatum)
+  def do_train(self, score, d):
+    """Syntax: train score datum_key datum_value [datum_key datum_value ...]
+    Trains the model with given score and datum.
+    Bulk training is not supported on the command line.
+    """
+    self._verbose("datum = {0}".format(d))
+    result = self.client.train([ScoredDatum(score, d)])
+    if result != 1:
+      print("Failed")
+
+  @Arguments(TDatum)
+  def do_estimate(self, d):
+    """Syntax: estimate datum_key datum_value [datum_key datum_value ...]
+    Estimate the score for the given datum.
+    Bulk estimation is not supported on the command line.
+    """
+    self._verbose("datum = {0}".format(d))
+    result = self.client.estimate([d])[0]
+    print(result)

--- a/jubakit/_cli/service/stat.py
+++ b/jubakit/_cli/service/stat.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.stat.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments
+from ..util import *
+
+class StatCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'stat'
+
+  @Arguments(str, float)
+  def do_push(self, key, value):
+    """Syntax: push key value
+    Add value for the specified key.
+    """
+    result = self.client.push(key, value)
+    if not result:
+      print("Failed")
+
+  @Arguments(str)
+  def do_sum(self, key):
+    """Syntax: sum key
+    Get sum for the specified key.
+    """
+    print(self.client.sum(key))
+
+  @Arguments(str)
+  def do_stddev(self, key):
+    """Syntax: stddev key
+    Get stddev for the specified key.
+    """
+    print(self.client.stddev(key))
+
+  @Arguments(str)
+  def do_max(self, key):
+    """Syntax: max key
+    Get max for the specified key.
+    """
+    print(self.client.max(key))
+
+  @Arguments(str)
+  def do_min(self, key):
+    """Syntax: min key
+    Get min for the specified key.
+    """
+    print(self.client.min(key))
+
+  @Arguments(str)
+  def do_entropy(self, key):
+    """Syntax: entropy key
+    Get entropy for the specified key.
+    """
+    print(self.client.entropy(key))
+
+  @Arguments(str, int, float)
+  def do_moment(self, key, n, c):
+    """Syntax: moment key n c
+    Get n-th moment about c of values in the specified key.
+    """
+    print(self.client.moment(key, n, c))

--- a/jubakit/_cli/service/weight.py
+++ b/jubakit/_cli/service/weight.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubatus.weight.types import *
+
+from .generic import GenericCLI
+from ..args import Arguments, TDatum
+from ..util import *
+
+class WeightCLI(GenericCLI):
+  @classmethod
+  def _name(cls):
+    return 'weight'
+
+  @Arguments(TDatum)
+  def do_update(self, d):
+    """Syntax: update datum_key datum_value [...]
+    Updates the model using the datum and calculates weights for it.
+    """
+    self._verbose("datum = {0}".format(d))
+    for f in self.client.update(d):
+      print('{0}\t{1}'.format(f.key, f.value))
+
+  @Arguments(TDatum)
+  def do_calc_weight(self, d):
+    """Syntax: calc_weight datum_key datum_value [...]
+    Calculates weights for the datum.
+    """
+    self._verbose("datum = {0}".format(d))
+    for f in self.client.calc_weight(d):
+      print('{0}\t{1}'.format(f.key, f.value))
+

--- a/jubakit/_cli/util.py
+++ b/jubakit/_cli/util.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+import shlex
+
+from ..compat import builtins, shell_split
+
+__all__ = [
+  'print',
+  'set_cli_output',
+  'get_cli_output',
+  'comp_position',
+  'filter_candidates',
+]
+
+class _CLIOutput(object):
+  _f = sys.stdout
+
+def print(*args, **kwargs):
+  """
+  ``print`` method for CLI output.
+  """
+  builtins.print(file=_CLIOutput._f, *args, **kwargs)
+
+def set_cli_output(f):
+  _CLIOutput._f = f
+
+def get_cli_output():
+  return _CLIOutput._f
+
+def comp_position(text, line, begidx, endidx):
+  """
+  Returns the current completion position of the argument.
+  """
+  return len(shell_split(line[:begidx])) - 1
+
+def filter_candidates(text, candidates):
+  """
+  Filters completion candidates by the text being entered.
+  """
+  return [x for x in candidates if x.startswith(text)]

--- a/jubakit/compat.py
+++ b/jubakit/compat.py
@@ -4,12 +4,27 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 import itertools
+import shlex
 
+try:
+  # Python 3
+  import builtins
+except ImportError:
+  # Python 2
+  import __builtin__ as builtins
+
+PYTHON2_6 = sys.version_info[:2] == (2, 6)
 PYTHON3 = sys.version_info >= (3, 0)
 
 zip_longest = itertools.zip_longest if PYTHON3 else itertools.izip_longest
 unicode_t = str if PYTHON3 else unicode
 long_t = int if PYTHON3 else long
+
+def shell_split(s):
+  if isinstance(s, unicode_t) and PYTHON2_6:
+    # shlex does not support Unicode on Python 2.6
+    return map(lambda x: x.decode(), shlex.split(s.encode()))
+  return shlex.split(s)
 
 if not PYTHON3:
   # Python 2.x

--- a/jubakit/dumb.py
+++ b/jubakit/dumb.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+"""
+*Dumb* Service is a kind of temporary implementations of Services.
+They are defined just for convenience.
+
+Unlike *Real* Services (Classifier, Anomaly, ...) which are defined
+in each file (classifier.py, anomaly.py, ...), Dumb Services cannot
+handle Datasets and Schemas.
+
+Each service has a field called ``CONFIG``, which provides a default
+config data structure for the service.  So you can use jubakit to start
+a Jubatus server processe, then directly use the raw Client class to
+make RPC calls.
+
+  >>> from jubakit.dumb import Stat
+  >>> service = Stat.run(Stat.CONFIG)
+  >>> client = service._client()
+  >>> client.push('x', 12)
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from jubakit.base import BaseService
+
+import jubatus
+
+class Bandit(BaseService):
+  CONFIG = {'method': 'ucb1', 'parameter': {'assume_unrewarded': False}}
+
+  @classmethod
+  def name(cls):           return 'bandit'
+  @classmethod
+  def _client_class(cls):  return jubatus.bandit.client.Bandit
+
+class Burst(BaseService):
+  CONFIG = {'method': 'burst', 'parameter': {'result_window_rotate_size': 5, 'max_reuse_batch_num': 5, 'batch_interval': 10, 'window_batch_size': 5, 'costcut_threshold': -1}}
+
+  @classmethod
+  def name(cls):           return 'burst'
+  @classmethod
+  def _client_class(cls):  return jubatus.burst.client.Burst
+
+class Clustering(BaseService):
+  CONFIG = {'method': 'kmeans', 'parameter': {'seed': 0, 'bicriteria_base_size': 10, 'forgetting_threshold': 0.5, 'bucket_size': 1000, 'k': 3, 'bucket_length': 2, 'compressor_method': 'simple', 'forgetting_factor': 0, 'compressed_bucket_size': 100}, 'converter': {'string_types': {'bigram': {'method': 'ngram', 'char_num': '2'}, 'trigram': {'method': 'ngram', 'char_num': '3'}, 'unigram': {'method': 'ngram', 'char_num': '1'}}, 'num_filter_types': {}, 'num_rules': [{'type': 'num', 'key': '*'}], 'num_filter_rules': [], 'string_filter_rules': [], 'num_types': {}, 'string_filter_types': {}, 'string_rules': [{'sample_weight': 'tf', 'global_weight': 'idf', 'type': 'bigram', 'key': '*'}]}}
+
+  @classmethod
+  def name(cls):           return 'clustering'
+  @classmethod
+  def _client_class(cls):  return jubatus.clustering.client.Clustering
+
+class Graph(BaseService):
+  CONFIG = {'method': 'graph_wo_index', 'parameter': {'damping_factor': 0.9, 'landmark_num': 5}}
+
+  @classmethod
+  def name(cls):           return 'graph'
+  @classmethod
+  def _client_class(cls):  return jubatus.graph.client.Graph
+
+class NearestNeighbor(BaseService):
+  CONFIG = {'method': 'lsh', 'parameter': {'hash_num': 64}, 'converter': {'string_types': {'bigram': {'method': 'ngram', 'char_num': '2'}, 'trigram': {'method': 'ngram', 'char_num': '3'}, 'unigram': {'method': 'ngram', 'char_num': '1'}}, 'num_filter_types': {}, 'num_rules': [{'type': 'num', 'key': '*'}], 'num_filter_rules': [], 'string_filter_rules': [], 'num_types': {}, 'string_filter_types': {}, 'string_rules': [{'sample_weight': 'tf', 'global_weight': 'idf', 'type': 'bigram', 'key': '*'}]}}
+
+  @classmethod
+  def name(cls):           return 'nearest_neighbor'
+  @classmethod
+  def _client_class(cls):  return jubatus.nearest_neighbor.client.NearestNeighbor
+
+class Recommender(BaseService):
+  CONFIG = {'method': 'inverted_index', 'converter': {'string_types': {'bigram': {'method': 'ngram', 'char_num': '2'}, 'trigram': {'method': 'ngram', 'char_num': '3'}, 'unigram': {'method': 'ngram', 'char_num': '1'}}, 'num_filter_types': {}, 'num_rules': [{'type': 'num', 'key': '*'}], 'num_filter_rules': [], 'string_filter_rules': [], 'num_types': {}, 'string_filter_types': {}, 'string_rules': [{'sample_weight': 'tf', 'global_weight': 'idf', 'type': 'bigram', 'key': '*'}]}}
+
+  @classmethod
+  def name(cls):           return 'recommender'
+  @classmethod
+  def _client_class(cls):  return jubatus.recommender.client.Recommender
+
+class Regression(BaseService):
+  CONFIG = {'method': 'PA', 'parameter': {'sensitivity': 0.1, 'regularization_weight': 3.402823e+38}, 'converter': {'string_types': {'bigram': {'method': 'ngram', 'char_num': '2'}, 'trigram': {'method': 'ngram', 'char_num': '3'}, 'unigram': {'method': 'ngram', 'char_num': '1'}}, 'num_filter_types': {}, 'num_rules': [{'type': 'num', 'key': '*'}], 'num_filter_rules': [], 'string_filter_rules': [], 'num_types': {}, 'string_filter_types': {}, 'string_rules': [{'sample_weight': 'tf', 'global_weight': 'idf', 'type': 'bigram', 'key': '*'}]}}
+
+  @classmethod
+  def name(cls):           return 'regression'
+  @classmethod
+  def _client_class(cls):  return jubatus.regression.client.Regression
+
+class Stat(BaseService):
+  CONFIG = {'window_size': 128}
+
+  @classmethod
+  def name(cls):           return 'stat'
+  @classmethod
+  def _client_class(cls):  return jubatus.stat.client.Stat

--- a/jubakit/shell.py
+++ b/jubakit/shell.py
@@ -1,0 +1,465 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+import optparse
+
+import msgpackrpc
+import jubatus
+
+from .compat import *
+from ._cli.base import BaseCLI, CLIInvalidatedException, CLIUnknownCommandException
+from ._cli.util import print, get_cli_output
+
+class JubaShell(object):
+  """
+  JubaShell provides a shell environment to call Jubatus RPC API.
+
+  The interactive interface is provided in ``cli`` submodule.
+  """
+
+  # Default shell prompt format.
+  _PS = '[Jubatus:{service}<{cluster}>@{host}:{port}] # '
+
+  # Cached references for CLI classes.
+  _cli_classes = {}
+
+  # Cached references for Jubatus Client classes.
+  _client_classes = {}
+
+  # Error message.
+  _INTERFACE_MISMATCH_ERROR = \
+    'Interface mismatch error detected.  ' \
+    'This error occured because either your version of Jubatus Python ' \
+    'client library is not compatible with the server you are ' \
+    'connecting to, or using an incompatible shell (for example, ' \
+    'using Classifier shell against Anomaly server.)\n' \
+    'Version compatibility information can be found at:\n' \
+    '  https://github.com/jubatus/jubatus/wiki/Client-Compatibility-and-Documentation'
+
+  def __init__(self, host, port, cluster, service, **kwargs):
+    """
+    Creates a new shell environment using parameters specified.
+
+    If ``service`` is ``None``, it will be automatically probed.
+    """
+    self._host = host
+    self._port = port
+    self._cluster = cluster
+    self._service = None
+
+    self._client = None
+    self._timeout = kwargs.get('timeout', 10)
+    self._keepalive = kwargs.get('keepalive', False)
+    self._verbose = kwargs.get('verbose', False)
+    self._prompt_format = kwargs.get('prompt', self._PS)
+    self._input = kwargs.get('input', None)
+    self._output = kwargs.get('output', get_cli_output())
+
+    self.set_remote(host, port, cluster, service)
+
+  def interact(self):
+    """
+    Starts the interactive shell environment.
+    """
+    cli = self._new_cli()
+    while True:
+      try:
+        self.connect()
+        cli.cmdloop()
+        return True
+      except CLIUnknownCommandException as e:
+        print('Unknown command: {0}'.format(e))
+        print('Type `help` for commands available.')
+      except CLIInvalidatedException:
+        cli = self._new_cli()
+      except ValueError as e:
+        print('Invalid argument: {0}; use `help` command for details'.format(e))
+      except msgpackrpc.error.RPCError as e:
+        print('RPC Error ({0}:{1}): {2} ({3})'.format(self._host, self._port, type(e).__name__, e))
+      except JubaShellException as e:
+        print('Error: {0} ({1})'.format(type(e).__name__, e))
+      except KeyboardInterrupt:  # trap Ctrl-C
+        print()
+      except jubatus.common.client.InterfaceMismatch as e:
+        print('RPC Interface Mismatch ({0}:{1}): {2}'.format(self._host, self._port, e))
+        print(self._INTERFACE_MISMATCH_ERROR)
+        break  # abort interactive shell
+      except:
+        break;  # abort interactive shell
+      finally:
+        self.disconnect()
+    return False
+
+  def run(self, command):
+    """
+    Runs one-shot command.
+    """
+    cli = self._new_cli()
+    try:
+      self.connect()
+      print('>> {0}'.format(command))
+      cli.onecmd(command)
+      return True
+    except CLIInvalidatedException:
+      cli = self._new_cli()
+      return True
+    except CLIUnknownCommandException as e:
+      print('Unknown command: {0}'.format(e))
+      print('Type `help` for commands available.')
+    except ValueError as e:
+      print('Invalid argument: {0}'.format(e))
+    except msgpackrpc.error.RPCError as e:
+      print('RPC Error ({0}:{1}): {2} ({3})'.format(self._host, self._port, type(e).__name__, e))
+    except JubaShellException as e:
+      print('Error: {0} ({1})'.format(type(e).__name__, e))
+    except KeyboardInterrupt:  # trap Ctrl-C
+      print('Interrupted.')
+    except jubatus.common.client.InterfaceMismatch as e:
+      print('RPC Interface Mismatch ({0}:{1}): {2}'.format(self._host, self._port, e))
+      print(self._INTERFACE_MISMATCH_ERROR)
+    finally:
+      self.disconnect()
+    return False
+
+  def connect(self):
+    """
+    Discard the current connection (if connected) and create new client instance.
+    Note that TCP connection will not be established until RPC method is called.
+    """
+    self.disconnect()
+    self._client = self._new_client()
+
+  def disconnect(self):
+    """
+    Disconnects from the server (if connected).
+    """
+    if self.is_connected():
+      cli = self._client.get_client()
+      cli.close()
+      cli._loop._ioloop.close()
+      self._client = None
+
+  def is_connected(self):
+    """
+    Returns True if the client exists.
+    Note that its backend TCP connection may already be closed.
+    """
+    return self._client is not None
+
+  def set_remote(self, host, port, cluster, service):
+    """
+    Switches to the new remote server.
+    """
+    self.disconnect()
+
+    self._host = host
+    self._port = port
+    self._cluster = cluster
+
+    if service is None:
+      service = self.probe_facts(host, port, cluster)[0]
+
+    self._service = service
+
+  def get_client(self):
+    """
+    Returns the client instance.
+    """
+    if not self.is_connected():
+      self.connect()
+    return self._client
+
+  def get_timeout(self):
+    """
+    Returns the current client-side timeout value.
+    """
+    return self._timeout
+
+  def set_timeout(self, timeout):
+    """
+    Sets new client-side timeout value.
+    Existing connection will be discarded.
+    """
+    self.disconnect()
+    self._timeout = timeout
+
+  def _new_client(self):
+    """
+    Returns new Jubatus client instance.
+    """
+    service = self._service
+    clients = self.get_client_classes()
+    if service not in clients:
+      print('Notice: Jubatus Client for {0} service not found, falling back to generic client'.format(service))
+      service = 'generic'
+
+    return clients[service](self._host, self._port, self._cluster, self._timeout)
+
+  def _new_cli(self):
+    """
+    Returns new CLI instance.
+    """
+    service = self._service
+    clis = self.get_cli_classes()
+    if service not in clis:
+      print('Notice: CLI for {0} service not found, falling back to generic CLI'.format(service))
+      service = 'generic'
+
+    cli = clis[service](self, stdin=self._input, stdout=self._output)
+    if self._input:
+      cli.use_rawinput = False
+    cli.prompt = self._prompt_format.format(
+      service=self._service,
+      host=self._host,
+      port=self._port,
+      cluster=self._cluster,
+    )
+
+    return cli
+
+  @classmethod
+  def probe_facts(cls, host, port, cluster):
+    """
+    Probe the service name and remote server type.
+    Returns tuple of (service_name, is_proxy).
+    """
+    # Get status from remote server.
+    client = jubatus.common.client.ClientBase(host, port, cluster, 0)
+    status = None
+    is_proxy = bool(cluster)  # only when cluster is non-empty string
+
+    try:
+      if is_proxy:
+        try:
+          results = client.get_proxy_status()
+          if len(results) != 1:
+            raise JubaShellAssertionError('unexpected get_proxy_status response', host, port, cluster, results)
+          status = results.popitem()[1]
+        except jubatus.common.client.UnknownMethod:
+          is_proxy = False
+      if not is_proxy:
+        results = client.get_status()
+        if len(results) == 0:
+          raise JubaShellAssertionError('unexpected get_status response', host, port, cluster, results)
+        status = results.popitem()[1]
+    except msgpackrpc.error.RPCError as e:
+      raise JubaShellRPCError('failed to auto-detect service type', host, port, e)
+    finally:
+      cli = client.get_client()
+      cli.close()
+      cli._loop._ioloop.close()
+
+    # Extract service name from the process name.
+    if not 'PROGNAME' in status:
+      raise JubaShellAssertionError('no program name returned from server', host, port, cluster, status)
+    service = status['PROGNAME']
+    if service.startswith('juba'):
+      service = service[4:]
+    if is_proxy and service.endswith('_proxy'):
+      service = service[:-6]
+
+    return (service, is_proxy)
+
+  @classmethod
+  def _get_subclasses(cls, clazz):
+    """
+    Finds all subclasses of the ``clazz``.
+    """
+    result = set()
+    queue = [clazz]
+    while queue:
+      parent = queue.pop()
+      for child in parent.__subclasses__():
+        if child not in result:
+          result.add(child)
+          queue.append(child)
+    return result
+
+  @classmethod
+  def get_client_classes(cls):
+    """
+    Returns map of service name to Jubatus client instance.
+    """
+    # Reuse cache.
+    clients = cls._client_classes
+    if len(clients) != 0:
+      return clients
+
+    client_classes = cls._get_subclasses(jubatus.common.client.ClientBase)
+    for clazz in client_classes:
+      # Extract "abc" part from "jubatus.abc.client" (module name).
+      name = clazz.__module__.split('.')[-2]
+      clients[name] = clazz
+
+    clients['generic'] = jubatus.common.client.ClientBase
+
+    cls._clients = clients
+    return clients
+
+  @classmethod
+  def get_cli_classes(cls):
+    """
+    Returns map of service name to CLI implementation class.
+    """
+    # Reuse cache.
+    clis = cls._cli_classes
+    if len(clis) != 0:
+      return clis
+
+    cli_classes = cls._get_subclasses(BaseCLI)
+    for clazz in cli_classes:
+      try:
+        name = clazz._name()
+        clis[name] = clazz
+      except NotImplementedError:  # it is an abstract class
+        continue
+
+    cls._clis = clis
+    return clis
+
+class JubaShellException(Exception):
+  pass
+
+class JubaShellAssertionError(JubaShellException):
+  pass
+
+class JubaShellRPCError(JubaShellException):
+  def __init__(self, msg, host, port, e=None):
+    errmsg = 'RPC Error ({0}:{1}): {2}'.format(host, port, msg)
+    if e:
+      errmsg += ' ({0}: {1})'.format(type(e).__name__, str(e))
+    super(JubaShellRPCError, self).__init__(errmsg)
+
+class JubashOptionParser(optparse.OptionParser, object):
+  def __init__(self, *args, **kwargs):
+    self._error = False
+    super(JubashOptionParser, self).__init__(*args, **kwargs)
+
+  def error(self, msg):
+    print('Error: {0}'.format(msg))
+    self._error = True
+
+class JubashCommand(object):
+  """
+  Provides command line interface for ``jubash`` command.
+  """
+
+  @classmethod
+  def start(cls, args):
+    USAGE = '''
+    jubash [--host HOST] [--port PORT] [--cluster CLUSTER]
+           [--service SERVICE] [--command COMMAND]
+           [--keepalive] [--fail-fast] [--prompt PROMPT]
+           [--verbose] [--debug] [--help] [script ...]'''
+    EPILOG = '  script ...            execute shell script instead of interactive shell'
+
+    services = sorted(JubaShell.get_cli_classes().keys())
+
+    # TODO: migrate to argparse (which must be added into dependency to support Python 2.6)
+    parser = JubashOptionParser(add_help_option=False, usage=USAGE, epilog=EPILOG)
+
+    parser.add_option('-H', '--host', type='string', default='127.0.0.1',
+                      help='host name or IP address of the server / proxy (default: %default)')
+    parser.add_option('-P', '--port', type='int',  default=9199,
+                      help='port number of the server / proxy (default: %default)')
+    parser.add_option('-C', '--cluster', type='string', default='',
+                      help='cluster name; only required when connecting to proxy')
+    parser.add_option('-s', '--service', type='string', default=None,
+                      help='type of the server; see below for services available (default: auto-detect)')
+    parser.add_option('-e', '--engine', type='string', default=None,
+                      help='(deprecated) equivalent to --service')
+    parser.add_option('-c', '--command', type='string', default=None,
+                      help='run one-shot command instead of interactive shell')
+    parser.add_option('-t', '--timeout', type='int', default=10,
+                      help='client-side timeout in seconds (default: %default)')
+    parser.add_option('-k', '--keepalive', default=False, action='store_true',
+                      help='use keep-alive connection; recommended when server-side timeout is disabled')
+    parser.add_option('-F', '--fail-fast', default=False, action='store_true',
+                      help='exit on error when running script')
+    parser.add_option('-p', '--prompt', type='string', default=JubaShell._PS,
+                      help='use customized shell prompt (default: %default)')
+    parser.add_option('-v', '--verbose', default=False, action='store_true',
+                      help='turn on verbose mode')
+    parser.add_option('-d', '--debug', default=False, action='store_true',
+                      help='turn on debug mode')
+    parser.add_option('-h', '--help', default=False, action='store_true',
+                      help='print the usage and exit')
+
+    def print_usage():
+      print('Jubash - Jubatus Shell')
+      print()
+      parser.print_help(get_cli_output())
+      print()
+      print('Available Services:')
+      print('  {0}'.format(', '.join(services)))
+
+    (args, scripts) = parser.parse_args(args)
+
+    # Failed to parse options.
+    if parser._error:
+      print_usage()
+      return 2
+
+    # Help option is specified.
+    if args.help:
+      print_usage()
+      return 0
+
+    # Support for deprecated parameters.
+    if args.service is None:
+      args.service = args.engine
+
+    # Validate parameters.
+    if args.port < 1 or 65535 < args.port:
+      print('Error: port number out of range: {0}'.format(args.port))
+      print_usage()
+      return 1
+    if args.service is not None and args.service not in services:
+      print('Error: unknown service name: {0}'.format(args.service))
+      print_usage()
+      return 1
+
+    success = False
+    try:
+      # Create shell instance.
+      shell = JubaShell(
+        host=args.host,
+        port=args.port,
+        cluster=args.cluster,
+        service=args.service,
+        timeout=args.timeout,
+        keepalive=args.keepalive,
+        verbose=args.verbose,
+        prompt=args.prompt,
+      )
+
+      # Run the shell.
+      if args.command:
+        # One-shot command mode.
+        success = shell.run(args.command)
+      elif len(scripts) != 0:
+        # Batch script mode.
+        for script in scripts:
+          success = True
+          # TODO improve handling of lines and support keepalive mode
+          for line in open(script, 'r'):
+            line = line.rstrip()
+            if line and not line.startswith('#'):
+              success = shell.run(line)
+              if not success and args.fail_fast: break
+      else:
+        # Interactive shell mode.
+        success = shell.interact()
+    except JubaShellException as e:
+      if args.debug: raise
+      print('{0}: {1}'.format(type(e).__name__, e))
+
+    return 0 if success else 3
+
+def main():
+  """
+  Entry point for ``jubash`` command.
+  """
+  sys.exit(JubashCommand.start(sys.argv[1:]))

--- a/jubakit/test/integration/_cli/service/base.py
+++ b/jubakit/test/integration/_cli/service/base.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+class BaseCLITestCase(TestCase):
+  def __init__(self, *args, **kwargs):
+    super(BaseCLITestCase, self).__init__(*args, **kwargs)
+
+  def _shell(self, input=None):
+    return self._service._shell(input=input)
+
+  def _cli(self, clazz, pre_commands=[]):
+    cli = clazz(self._shell())
+    for cmd in pre_commands:
+      cli.onecmd(cmd)
+    return cli
+
+  def _ok(self, commands):
+    for cmd in commands:
+      self.assertTrue(self._shell().run(cmd), cmd)
+
+  def _fail(self, commands):
+    for cmd in commands:
+      self.assertFalse(self._shell().run(cmd), cmd)

--- a/jubakit/test/integration/_cli/service/test_anomaly.py
+++ b/jubakit/test/integration/_cli/service/test_anomaly.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.anomaly import Anomaly, Config
+from jubakit._cli.service import AnomalyCLI
+
+from .base import BaseCLITestCase
+
+class AnomalyCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Anomaly.run(Config())
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'add x 1 y 1',
+      'update p1 x 1 y 2',
+      'overwrite p2 x 1 y 3',
+      'calc_score x 1 y 4',
+      'get_all_rows',
+    ])
+    self.assertEqual(set(self._service._client().get_all_rows()), set(['0', 'p1', 'p2']))
+
+  def test_fail(self):
+    self._fail([
+      'train',
+      'add x 1 y',
+      'update x 1',
+      'overwrite x 1',
+      'calc_score x',
+      'get_all_rows foo',
+      'clear_row',
+    ])

--- a/jubakit/test/integration/_cli/service/test_bandit.py
+++ b/jubakit/test/integration/_cli/service/test_bandit.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.dumb import Bandit
+from jubakit._cli.service import BanditCLI
+
+from .base import BaseCLITestCase
+
+class BanditCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Bandit.run(Bandit.CONFIG)
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'register_arm a1',
+      'register_arm a2',
+      'register_arm a3',
+      'delete_arm a3',
+      'select_arm p1',
+      'select_arm p2',
+      'register_reward p1 a1 100',
+      'register_reward p2 a2 100',
+      'get_arm_info p1',
+      'reset p1',
+    ])
+    self.assertEqual(set(self._service._client().get_arm_info('p1').keys()), set(['a1', 'a2']))
+
+  def test_fail(self):
+    self._fail([
+      'register_arm',
+      'register_arm x y',
+      'delete_arm',
+      'select_arm',
+      'register_reward',
+      'register_reward p a x',
+      'get_arm_info',
+      'reset',
+    ])

--- a/jubakit/test/integration/_cli/service/test_burst.py
+++ b/jubakit/test/integration/_cli/service/test_burst.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.dumb import Burst
+from jubakit._cli.service import BurstCLI
+
+from .base import BaseCLITestCase
+
+class BurstCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Burst.run(Burst.CONFIG)
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'add_keyword test',
+      'add_document "test text"',
+      'add_document "test text" 100',
+      'get_result test',
+      'get_result test 100',
+      'get_all_bursted_results',
+      'get_all_bursted_results 100',
+      'get_all_keywords',
+      'remove_keyword test',
+      'remove_all_keywords',
+      'add_keyword bar',
+    ])
+    keywords = map(lambda x: x.keyword, self._service._client().get_all_keywords())
+    self.assertEqual(set(keywords), set(['bar']))
+
+  def test_fail(self):
+    self._fail([
+      'add_keyword foo bar',
+      'add_document',
+      'add_documents',
+      'get_result',
+      'get_result test foo',
+      'get_all_bursted_results foo',
+      'get_all_keywords bar',
+      'remove_all_keywords bar',
+    ])

--- a/jubakit/test/integration/_cli/service/test_classifier.py
+++ b/jubakit/test/integration/_cli/service/test_classifier.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.classifier import Classifier, Config
+from jubakit._cli.service import ClassifierCLI
+
+from .base import BaseCLITestCase
+
+class ClassifierCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Classifier.run(Config())
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'train pos x 1 y 1',
+      'train neg x -1 y -1',
+      'classify x 2 y 2',
+      'set_label neutral',
+      'get_labels',
+      'delete_label pos',
+    ])
+    self.assertEqual(set(self._service._client().get_labels()), set(['neg', 'neutral']))
+
+  def test_fail(self):
+    self._fail([
+      'train',
+      'train pos x',
+      'classify x',
+      'set_label',
+      'delete_label',
+    ])
+
+  def test_complete_train(self):
+    cli = self._cli(ClassifierCLI, [
+      'train pos x 1 y 1',
+      'train neg x -1 y -1',
+    ])
+    candidates = cli.complete_train('', 'train ', 6, 6)
+    self.assertEqual(set(candidates), set(['pos', 'neg']))

--- a/jubakit/test/integration/_cli/service/test_clustering.py
+++ b/jubakit/test/integration/_cli/service/test_clustering.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.dumb import Clustering
+from jubakit._cli.service import ClusteringCLI
+
+from .base import BaseCLITestCase
+
+class ClusteringCLITest(BaseCLITestCase):
+  def setUp(self):
+    cfg = Clustering.CONFIG
+    cfg['parameter']['bucket_size'] = 3
+    cfg['parameter']['compressed_bucket_size'] = 2
+    cfg['parameter']['bicriteria_base_size'] = 1
+    self._service = Clustering.run(cfg)
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'push x 1 y 1',
+      'push x 1 y 2',
+      'push x 1 y 3',
+      'push x 5 y 1',
+      'push x 5 y 2',
+      'push x 5 y 3',
+      'get_revision',
+      'get_k_center',
+      'get_nearest_center x 1 y 1',
+      'get_nearest_members x 5 y 5',
+      'get_core_members',
+    ])
+    self.assertEqual(self._service._client().get_revision(), 2)
+
+  def test_fail(self):
+    self._fail([
+      'push x',
+      'get_revision foo',
+      'get_k_center foo',
+      'get_nearest_center x 1 y',
+      'get_nearest_members x',
+      'get_core_members foo',
+    ])

--- a/jubakit/test/integration/_cli/service/test_generic.py
+++ b/jubakit/test/integration/_cli/service/test_generic.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.classifier import Classifier, Config
+from jubakit._cli.service import GenericCLI
+
+from .base import BaseCLITestCase
+
+class GenericCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Classifier.run(Config())
+    self._sh = self._service._shell()
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    host = self._service._host
+    port = self._service._port
+
+    self._ok([
+      'clear',
+      'get_config',
+      'save test',
+      'load test',
+      'get_status',
+      # TODO consider distributed mode test
+      #'get_proxy_status',
+      #'do_mix',
+      'connect {0} {1}'.format(host, port),
+      'connect {0} {1} foo'.format(host, port),
+      'reconnect',
+      'verbose',
+      'keepalive',
+      'timeout',
+      'timeout 10',
+      'help',
+      'exit',
+    ])
+
+  def test_fail(self):
+    self._fail([
+      'clear foo',
+      'save',
+      'load',
+      'error',
+      'verbose on',
+      'timeout xx',
+    ])
+
+  def test_complete_command(self):
+    cli = self._cli(GenericCLI)
+    cli.complete('', 0)
+
+    commands = set(cli.completion_matches)
+    expected_commands = set(
+      ['help', 'exit'] +
+      ['connect', 'reconnect', 'verbose', 'keepalive', 'timeout'] +
+      ['get_config', 'save', 'load', 'clear', 'get_status', 'get_proxy_status', 'do_mix']
+    )
+    self.assertEqual(commands, expected_commands)

--- a/jubakit/test/integration/_cli/service/test_graph.py
+++ b/jubakit/test/integration/_cli/service/test_graph.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.dumb import Graph
+from jubakit._cli.service import GraphCLI
+
+from .base import BaseCLITestCase
+
+class GraphCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Graph.run(Graph.CONFIG)
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'create_node',            # 0
+      'create_node',            # 1
+      'create_node',            # 2
+      'create_node',            # 3
+      'update_node 1 k n1',
+      'update_node 2 k n2',
+      'update_node 3 k n3',
+      'create_edge 1 2 k e4',   # 4
+      'create_edge 2 3 k e5',   # 5
+      'update_edge 4 1 2 k eX',
+      'remove_edge 5',
+      'remove_node 3',
+      'add_centrality_query',
+      'add_shortest_path_query',
+      'update_index',
+      'get_centrality 1 0',
+      'get_shortest_path 1 2',
+      'get_shortest_path 1 2 100',
+      'remove_centrality_query',
+      'remove_shortest_path_query',
+      'get_node 1',
+      'get_edge 4',
+    ])
+    self.assertEqual(self._service._client().get_node('1').property, {'k': 'n1'})
+    self.assertEqual(self._service._client().get_edge('0', 4).property, {'k': 'eX'})
+
+  def test_fail(self):
+    self._fail([
+      'create_node foo',
+      'update_node',
+      'update_node foo bar baz',
+      'create_edge foo',
+      'update_edge foo bar baz',
+      'remove_node foo'
+      'remove_edge foo'
+      'add_centrality_query foo',
+      'add_shortest_path_query foo',
+      'update_index foo',
+      'get_centrality',
+      'get_shortest_path',
+      'remove_centrality_query foo',
+      'remove_shortest_path_query foo',
+      'get_node',
+      'get_edge',
+    ])

--- a/jubakit/test/integration/_cli/service/test_nearest_neighbor.py
+++ b/jubakit/test/integration/_cli/service/test_nearest_neighbor.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.dumb import NearestNeighbor
+from jubakit._cli.service import NearestNeighborCLI
+
+from .base import BaseCLITestCase
+
+class NearestNeighborCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = NearestNeighbor.run(NearestNeighbor.CONFIG)
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'set_row p1 x 1 y "foo"',
+      'set_row p2 x 2 y "bar"',
+      'neighbor_row_from_id p1',
+      'neighbor_row_from_datum x 1',
+      'similar_row_from_id p1',
+      'similar_row_from_datum x 1',
+      'get_all_rows',
+      'max_results',
+      'max_results 100',
+    ])
+    self.assertEqual(set(self._service._client().get_all_rows()), set(['p1', 'p2']))
+
+  def test_fail(self):
+    self._fail([
+      'set_row p1 x',
+      'neighbor_row_from_id',
+      'neighbor_row_from_datum x 1 y',
+      'similar_row_from_id x y',
+      'similar_row_from_datum x',
+      'get_all_rows foo',
+      'max_results abc',
+      'max_results 100 abc',
+    ])

--- a/jubakit/test/integration/_cli/service/test_recommender.py
+++ b/jubakit/test/integration/_cli/service/test_recommender.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.dumb import Recommender
+from jubakit._cli.service import RecommenderCLI
+
+from .base import BaseCLITestCase
+
+class RecommenderCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Recommender.run(Recommender.CONFIG)
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'update_row p1 x 1 y "foo"',
+      'update_row p2 x 2 y "bar"',
+      'complete_row_from_id p1',
+      'complete_row_from_datum x 1',
+      'similar_row_from_id p1',
+      'similar_row_from_datum x 1',
+      'decode_row p1',
+      'get_all_rows',
+      'calc_similarity x 1 y "foo" |',
+      'calc_similarity x 1 y "foo" | x 2 y "bar"',
+      'calc_l2norm x 1',
+      'max_results',
+      'max_results 100',
+    ])
+    self.assertEqual(set(self._service._client().get_all_rows()), set(['p1', 'p2']))
+
+  def test_fail(self):
+    self._fail([
+      'update_row p1 x',
+      'complete_row_from_id',
+      'complete_row_from_datum x 1 y',
+      'similar_row_from_id x y',
+      'similar_row_from_datum x',
+      'decode_row',
+      'get_all_rows foo',
+      'calc_similarity x 1 y',
+      'calc_similarity x 1 y "foo"',
+      'calc_similarity x 1 y "foo" | x',
+      'calc_l2norm x',
+      'max_results abc',
+      'max_results 100 abc',
+    ])

--- a/jubakit/test/integration/_cli/service/test_regression.py
+++ b/jubakit/test/integration/_cli/service/test_regression.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.dumb import Regression
+from jubakit._cli.service import RegressionCLI
+
+from .base import BaseCLITestCase
+
+class RegressionCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Regression.run(Regression.CONFIG)
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'train 10 x 1 y 1',
+      'train -10 x -1 y -1',
+      'estimate x 100 y 100',
+    ])
+
+  def test_fail(self):
+    self._fail([
+      'train x',
+      'train 10 x',
+      'estimate x 100 y',
+    ])

--- a/jubakit/test/integration/_cli/service/test_stat.py
+++ b/jubakit/test/integration/_cli/service/test_stat.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.dumb import Stat
+from jubakit._cli.service import StatCLI
+
+from .base import BaseCLITestCase
+
+class StatCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Stat.run(Stat.CONFIG)
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'push x 1',
+      'push x 2',
+      'push y 3',
+      'push y 4',
+      'sum x',
+      'stddev y',
+      'max x',
+      'min y',
+      'entropy x',
+      'moment y 0 1',
+    ])
+    self.assertEqual(self._service._client().max('x'), 2)
+    self.assertEqual(self._service._client().max('y'), 4)
+
+  def test_fail(self):
+    self._fail([
+      'push',
+      'push x 1 2',
+      'sum',
+      'stddev',
+      'max',
+      'min',
+      'entropy',
+      'moment x x x x',
+    ])

--- a/jubakit/test/integration/_cli/service/test_weight.py
+++ b/jubakit/test/integration/_cli/service/test_weight.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.weight import Weight, Config
+from jubakit._cli.service import WeightCLI
+
+from .base import BaseCLITestCase
+
+class WeightCLITest(BaseCLITestCase):
+  def setUp(self):
+    self._service = Weight.run(Config())
+
+  def tearDown(self):
+    self._service.stop()
+
+  def test_simple(self):
+    self._ok([
+      'clear',
+      'update x 1 y 1',
+      'calc_weight x 1 y 1',
+    ])
+
+  def test_fail(self):
+    self._fail([
+      'update x',
+      'calc_weight x 1 y',
+    ])

--- a/jubakit/test/integration/test_shell.py
+++ b/jubakit/test/integration/test_shell.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from io import StringIO
+
+from jubakit.shell import JubaShell, JubashCommand
+from jubakit.classifier import Classifier, Config
+
+class JubaShellTest(TestCase):
+  def setUp(self):
+    self._service = Classifier.run(Config())
+
+  def tearDown(self):
+    self._service.stop()
+
+  def _shell(self, cmd='', service_name=None):
+    s = self._service
+    if not service_name:
+      service_name = s.name()
+    shell = JubaShell(
+      s._host,
+      s._port,
+      s._cluster,
+      service_name,
+      input=StringIO(cmd),
+    )
+    return shell
+
+  def test_interact(self):
+    self.assertTrue(self._shell('classify x 1').interact())
+    self.assertTrue(self._shell('error').interact())
+    self.assertTrue(self._shell('connect 127.0.0.1 0').interact())
+    self.assertTrue(self._shell('! echo OK').interact())
+
+    # Interface mismatch (using anomaly shell against classifier service)
+    self.assertFalse(self._shell('calc_score x 1', 'anomaly').interact())
+
+  def test_run(self):
+    self.assertTrue(self._shell().run('classify x 1'))
+    self.assertFalse(self._shell().run('error'))
+    self.assertFalse(self._shell().run('connect 127.0.0.1 0'))
+    self.assertFalse(self._shell('', 'anomaly').run('calc_score x 1'))
+
+class JubashCommandTest(TestCase):
+  def setUp(self):
+    self._service = Classifier.run(Config())
+
+  def tearDown(self):
+    self._service.stop()
+
+  def _assert_exit(self, args, status):
+    self.assertEqual(JubashCommand.start(args), status)
+
+  def test_simple(self):
+    args = [
+      '--host', self._service._host,
+      '--port', str(self._service._port),
+      '--service', self._service.name(),
+      '--command', 'classify x 1',
+    ]
+    self._assert_exit(args, 0)
+
+  def test_service_estimate(self):
+    args = [
+      '--host', self._service._host,
+      '--port', str(self._service._port),
+      '--command', 'classify x 1',
+    ]
+    self._assert_exit(args, 0)

--- a/jubakit/test/test_shell.py
+++ b/jubakit/test/test_shell.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+from unittest import TestCase
+
+import jubatus
+
+from jubakit.shell import JubaShell, JubashCommand
+from jubakit._cli.util import set_cli_output
+
+# Ignore output from CLI classes
+set_cli_output(open(os.devnull, 'w'))
+
+class JubaShellTest(TestCase):
+  def test_get_client_classes(self):
+    classes = JubaShell.get_client_classes()
+    self.assertTrue('generic' in classes)
+    self.assertTrue('classifier' in classes)
+    self.assertTrue('stat' in classes)
+
+  def test_get_cli_classes(self):
+    classes = JubaShell.get_cli_classes()
+    self.assertTrue('generic' in classes)
+    self.assertTrue('classifier' in classes)
+    self.assertTrue('stat' in classes)
+
+class JubashCommandTest(TestCase):
+  def _assert_exit(self, args, status):
+    self.assertEqual(JubashCommand.start(args), status)
+
+  def test_help(self):
+    args = ['--help']
+    self._assert_exit(args, 0)
+
+  def test_invalid_param(self):
+    args = ['--port', '0']
+    self._assert_exit(args, 1)
+
+    args = ['--service', 'unknown']
+    self._assert_exit(args, 1)
+
+    args = ['--engine', 'unknown']
+    self._assert_exit(args, 1)
+
+    args = ['--no-such-option']
+    self._assert_exit(args, 2)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(name='jubakit',
           'Programming Language :: Python :: 3.5',
       ],
       packages=find_packages(exclude=['jubakit.test']),
+      entry_points={
+          'console_scripts': ['jubash=jubakit.shell:main'],
+      },
       install_requires=[
           'jubatus>=0.8.0',
           'psutil',


### PR DESCRIPTION
This PR adds CLI feature to Jubakit; implements #38.
It was originally provided in [kmaehashi/jubash](https://github.com/kmaehashi/jubash) but now it is integrated into jubakit.

This PR also contains partial fixes for #47.

There are two usages for jubash:

### Running shell from Jubakit Service

From Python code using jubakit, you can start interactive shell from Service classes' `shell()` method.

```py
for (idx, row_id, flag, score) in anomaly.calc_score(dataset):
  if score == float('nan'):
    anomaly.shell()  # drop into interactive shell; the process continues when shell exits.
```

So you can manually throw ad-hoc RPC queries anytime.

### Running shell via interactive command

You can run the interactive shell from outside jubakit script, by invoking a standalone command named `jubash`:
 
```
(bash) $ jubash --host 127.0.0.1 --port 9199
[Jubatus:classifier<>@127.0.0.1:9199] # train male height 170 weight 60
[Jubatus:classifier<>@127.0.0.1:9199] # train male height 185 weight 65
[Jubatus:classifier<>@127.0.0.1:9199] # train female height 150 weight 50
[Jubatus:classifier<>@127.0.0.1:9199] # train female height 155 weight 45
[Jubatus:classifier<>@127.0.0.1:9199] # classify height 140 weight 40
female: 1.0111604929
male: 0.0962741076946
```

In this case you can use `jubash` for Jubatus servers started outside jubakit world.
All engines are supported.

More advanced usages are in the [original README](https://github.com/kmaehashi/jubash/blob/master/README.md#usage).