### PR TITLE
add classifier data loader

### DIFF
--- a/jubakit/classifier.py
+++ b/jubakit/classifier.py
@@ -61,7 +61,7 @@ class Dataset(BaseDataset):
 
     Parameters
     ----------
-    data : array or scipy 2-D sparse matrix of shape [n_samples, n_features] ]
+    data : array or scipy 2-D sparse matrix of shape [n_samples, n_features]
     labels : array of shape [n_samples]
     feature_names : array of shape [n_features], optional
     label_names : array of shape [n_labels], optional

--- a/jubakit/classifier.py
+++ b/jubakit/classifier.py
@@ -55,6 +55,23 @@ class Dataset(BaseDataset):
     return Dataset(loader, schema, static)
 
   @classmethod
+  def from_data(cls, data, labels, feature_names=None, label_names=None, static=True):
+    """ 
+    Converts two arrays or a sparse matrix data and its associated label array to Dataset.
+
+    Parameters
+    ----------
+    data : array or scipy 2-D sparse matrix of shape [n_samples, n_features] ]
+    labels : array of shape [n_samples]
+    feature_names : array of shape [n_features], optional
+    label_names : array of shape [n_labels], optional
+    """
+    if hasattr(data, 'todense'):
+        return cls.from_matrix(data, labels, feature_names, label_names, static)
+    else:
+        return cls.from_array(data, labels, feature_names, label_names, static)
+  
+  @classmethod
   def from_array(cls, data, labels, feature_names=None, label_names=None, static=True):
     """
     Converts two arrays (data and its associated labels) to Dataset.

--- a/jubakit/test/test_classifier.py
+++ b/jubakit/test/test_classifier.py
@@ -86,6 +86,7 @@ class DatasetTest(TestCase):
     # when actually iterating over it, pass it to list().
     self.assertRaises(RuntimeError, list, ds.get_labels())
 
+  @requireSklearn
   def test_from_data(self):
     # load from array format 
     ds = Dataset.from_data(

--- a/jubakit/test/test_classifier.py
+++ b/jubakit/test/test_classifier.py
@@ -86,7 +86,7 @@ class DatasetTest(TestCase):
     # when actually iterating over it, pass it to list().
     self.assertRaises(RuntimeError, list, ds.get_labels())
 
-  def test_from(self):
+  def test_from_data(self):
     # load from array format 
     ds = Dataset.from_data(
         [ [10,20,30], [20,10,50], [40,10,30] ], # data

--- a/jubakit/test/test_classifier.py
+++ b/jubakit/test/test_classifier.py
@@ -86,6 +86,49 @@ class DatasetTest(TestCase):
     # when actually iterating over it, pass it to list().
     self.assertRaises(RuntimeError, list, ds.get_labels())
 
+  def test_from(self):
+    # load from array format 
+    ds = Dataset.from_data(
+        [ [10,20,30], [20,10,50], [40,10,30] ], # data
+        [ 0,          1,          0          ], # labels
+        ['k1', 'k2', 'k3'],                     # feature_names
+        ['pos', 'neg'],                         # label_names
+    )
+
+    expected_labels = ['pos', 'neg', 'pos']
+    expected_k1s = [10, 20, 40]
+    actual_labels = []
+    actual_k1s = []
+    for (idx, (label, d)) in ds:
+      actual_labels.append(label)
+      actual_k1s.append(dict(d.num_values)['k1'])
+
+    self.assertEqual(expected_labels, actual_labels)
+    self.assertEqual(expected_k1s, actual_k1s)
+
+    # load from scipy.sparse format
+    ds = Dataset.from_data(
+      self._create_matrix(),    # data
+      [ 0, 1, 0 ],              # labels
+      [ 'k1', 'k2', 'k3'],      # feature_names
+      [ 'pos', 'neg'],          # label_names
+    )
+
+    expected_labels = ['pos', 'neg', 'pos']
+    expected_k1s = [1, None, 4]
+    expected_k3s = [2, 3, 6]
+    actual_labels = []
+    actual_k1s = []
+    actual_k3s = []
+    for (idx, (label, d)) in ds:
+      actual_labels.append(label)
+      actual_k1s.append(dict(d.num_values).get('k1', None))
+      actual_k3s.append(dict(d.num_values).get('k3', None))
+
+    self.assertEqual(expected_labels, actual_labels)
+    self.assertEqual(expected_k1s, actual_k1s)
+    self.assertEqual(expected_k3s, actual_k3s)
+
   def test_from_array(self):
     ds = Dataset.from_array(
         [ [10,20,30], [20,10,50], [40,10,30] ], # data


### PR DESCRIPTION
Using this PR, we don't have to specify data format when loading from array or sparse.matrix in classifier service.