### PR TITLE
improve exception handling in jubash

### DIFF
--- a/jubakit/test/integration/test_shell.py
+++ b/jubakit/test/integration/test_shell.py
@@ -42,6 +42,8 @@ class JubaShellTest(TestCase):
     self.assertTrue(self._shell().run('classify x 1'))
     self.assertFalse(self._shell().run('error'))
     self.assertFalse(self._shell().run('connect 127.0.0.1 0'))
+    self.assertFalse(self._shell().run('connect 127.0.0.1 -1'))
+    self.assertFalse(self._shell().run('connect this_must_be_unknown_host 9199'))
     self.assertFalse(self._shell('', 'anomaly').run('calc_score x 1'))
 
 class JubashCommandTest(TestCase):


### PR DESCRIPTION
* Socket exceptions were not caught.  This may become a problem when the host name is unresolvable (e.g. ``connect unresolvable_host_name 9199``) or using wrong port number (e.g., ``connect 127.0.0.1 -1``).
* There was a wrong code in exception handling that squashes all exceptions raised in the command loop.  It must be removed; catch-all should be done in main (``JubashCommand.start``) instead.
* Reordered exception handling; just to keep ``interact`` and ``run`` look consistent.