### PR TITLE
improve Classifier service to accept Schema without LABEL (fix #40)

### DIFF
--- a/jubakit/classifier.py
+++ b/jubakit/classifier.py
@@ -42,40 +42,44 @@ class Dataset(BaseDataset):
 
   @classmethod
   def _from_loader(cls, data_loader, labels, label_names, static):
-    # Label is feeded with '_label' key from Loader.
-    label_loader = ZipArrayLoader(_label=labels)
-    if label_names is not None:
-      label_loader = ValueMapChainLoader(label_loader, '_label', label_names)
-    loader = MergeChainLoader(data_loader, label_loader)
-    schema = Schema({'_label': Schema.LABEL}, Schema.NUMBER)
+    if labels is None:
+      loader = data_loader
+      schema = Schema({}, Schema.NUMBER)
+    else:
+      # Label is feeded with '_label' key from Loader.
+      label_loader = ZipArrayLoader(_label=labels)
+      if label_names is not None:
+        label_loader = ValueMapChainLoader(label_loader, '_label', label_names)
+      loader = MergeChainLoader(data_loader, label_loader)
+      schema = Schema({'_label': Schema.LABEL}, Schema.NUMBER)
     return Dataset(loader, schema, static)
 
   @classmethod
-  def from_data(cls, data, labels, feature_names=None, label_names=None, static=True):
-    """ 
+  def from_data(cls, data, labels=None, feature_names=None, label_names=None, static=True):
+    """
     Converts two arrays or a sparse matrix data and its associated label array to Dataset.
 
     Parameters
     ----------
     data : array or scipy 2-D sparse matrix of shape [n_samples, n_features]
-    labels : array of shape [n_samples]
+    labels : array of shape [n_samples], optional
     feature_names : array of shape [n_features], optional
     label_names : array of shape [n_labels], optional
     """
     if hasattr(data, 'todense'):
-        return cls.from_matrix(data, labels, feature_names, label_names, static)
+      return cls.from_matrix(data, labels, feature_names, label_names, static)
     else:
-        return cls.from_array(data, labels, feature_names, label_names, static)
-  
+      return cls.from_array(data, labels, feature_names, label_names, static)
+
   @classmethod
-  def from_array(cls, data, labels, feature_names=None, label_names=None, static=True):
+  def from_array(cls, data, labels=None, feature_names=None, label_names=None, static=True):
     """
     Converts two arrays (data and its associated labels) to Dataset.
 
     Parameters
     ----------
     data : array of shape [n_samples, n_features]
-    labels : array of shape [n_samples]
+    labels : array of shape [n_samples], optional
     feature_names : array of shape [n_features], optional
     label_names : array of shape [n_labels], optional
     """
@@ -83,7 +87,7 @@ class Dataset(BaseDataset):
     return cls._from_loader(data_loader, labels, label_names, static)
 
   @classmethod
-  def from_matrix(cls, data, labels, feature_names=None, label_names=None, static=True):
+  def from_matrix(cls, data, labels=None, feature_names=None, label_names=None, static=True):
     """
     Converts a sparse matrix data and its associated label array to Dataset.
 
@@ -91,7 +95,7 @@ class Dataset(BaseDataset):
     ----------
 
     data : scipy 2-D sparse matrix of shape [n_samples, n_features]
-    labels : array of shape [n_samples]
+    labels : array of shape [n_samples], optional
     feature_names : array of shape [n_features], optional
     label_names : array of shape [n_labels], optional
     """

--- a/jubakit/test/test_classifier.py
+++ b/jubakit/test/test_classifier.py
@@ -144,6 +144,25 @@ class DatasetTest(TestCase):
     self.assertEqual(expected_labels, actual_labels)
     self.assertEqual(expected_k1s, actual_k1s)
 
+  def test_from_array_without_label(self):
+    ds = Dataset.from_array(
+        [ [10,20,30], [20,10,50], [40,10,30] ], # data
+        None,                                   # labels
+        ['k1', 'k2', 'k3'],                     # feature_names
+        ['pos', 'neg'],                         # label_names
+    )
+
+    expected_labels = [None, None, None]
+    expected_k1s = [10, 20, 40]
+    actual_labels = []
+    actual_k1s = []
+    for (idx, (label, d)) in ds:
+      actual_labels.append(label)
+      actual_k1s.append(dict(d.num_values)['k1'])
+
+    self.assertEqual(expected_labels, actual_labels)
+    self.assertEqual(expected_k1s, actual_k1s)
+
   @requireSklearn
   def test_from_matrix(self):
     ds = Dataset.from_matrix(

--- a/jubakit/test/test_classifier.py
+++ b/jubakit/test/test_classifier.py
@@ -31,19 +31,13 @@ class SchemaTest(TestCase):
     self.assertEqual(label, None)
     self.assertEqual({'k1': 'foo'}, dict(d.string_values))
 
-  def test_predict(self):
-    schema = Schema({
+  def test_without_label(self):
+    # schema without label can be defined
+    Schema({
       'k1': Schema.STRING,
-      'k2': Schema.LABEL,
     })
-    self.assertRaises(RuntimeError, schema.predict, {}, True)
 
   def test_illegal_label(self):
-    # schema without label
-    self.assertRaises(RuntimeError, Schema, {
-      'k1': Schema.STRING,
-    })
-
     # schema with multiple labels
     self.assertRaises(RuntimeError, Schema, {
       'k1': Schema.LABEL,
@@ -69,7 +63,8 @@ class DatasetTest(TestCase):
 
   def test_predict(self):
     loader = StubLoader()
-    self.assertRaises(RuntimeError, Dataset, loader, None)
+    dataset = Dataset(loader)  # predict
+    self.assertEqual(['v', 1.0], dataset[0][1].num_values[0])
 
   def test_get_labels(self):
     loader = StubLoader()


### PR DESCRIPTION
Fix #40.  Classifier schema without LABEL can now be defined; such Datasets can only be used for classification task.