### PR TITLE
support embedded jubatus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.pyo
 /dist/
 /build/
 /*.egg-info

--- a/doc/source/architecture/service.rst
+++ b/doc/source/architecture/service.rst
@@ -50,6 +50,25 @@ Jubakit can even be used with externally managed Jubatus processes.
 
   # ... do some train/classify tasks ...
 
+Embedded Jubatus
+----------------
+
+Jubakit can use "embedded" version of Jubatus as a backend, which reduces the cost of process invocation and RPC overhead.
+
+.. code-block:: python
+
+  from jubakit.classifier import Config, Classifier
+
+  # Create a default configuration.
+  cfg = Config()
+
+  # Create a new service in "Embedded" mode.
+  classifier_service = Classifier.run(cfg, embedded=True)
+
+  # ... do some train/classify tasks ...
+
+To use "embedded" feature, ``embedded_jubatus`` ([embedded-jubatus-python](https://github.com/jubatus/embedded-jubatus-python)) Python module, which is a wrapper module to call machine learning algorithms provided in Jubatus Core library, needs to be installed.
+
 List of Services
 ----------------
 

--- a/jubakit/anomaly.py
+++ b/jubakit/anomaly.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import jubatus
+import jubatus.embedded
 
 from .base import GenericSchema, BaseDataset, BaseService, GenericConfig
 from .compat import *
@@ -54,6 +55,10 @@ class Anomaly(BaseService):
   @classmethod
   def _client_class(cls):
     return jubatus.anomaly.client.Anomaly
+
+  @classmethod
+  def _embedded_class(cls):
+    return jubatus.embedded.Anomaly
 
   def add(self, dataset):
     """

--- a/jubakit/base.py
+++ b/jubakit/base.py
@@ -458,8 +458,8 @@ class BaseService(object):
   @classmethod
   def run(cls, config, port=None, embedded=False):
     """
-    Runs a new standalone server or embedded instnace and returns the
-    serivce instance.
+    Runs a new standalone server or embedded instance and returns the
+    service instance.
     """
     if embedded:
       backend = _ServiceBackendEmbedded(cls._embedded_class(), config)

--- a/jubakit/classifier.py
+++ b/jubakit/classifier.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import jubatus
+import jubatus.embedded
 
 from .base import GenericSchema, BaseDataset, BaseService, GenericConfig, Utils
 from .loader.array import ArrayLoader, ZipArrayLoader
@@ -125,6 +126,10 @@ class Classifier(BaseService):
   @classmethod
   def _client_class(cls):
     return jubatus.classifier.client.Classifier
+
+  @classmethod
+  def _embedded_class(cls):
+    return jubatus.embedded.Classifier
 
   def train(self, dataset):
     """

--- a/jubakit/dumb.py
+++ b/jubakit/dumb.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from jubakit.base import BaseService
 
 import jubatus
+import jubatus.embedded
 
 class Bandit(BaseService):
   CONFIG = {'method': 'ucb1', 'parameter': {'assume_unrewarded': False}}
@@ -32,6 +33,8 @@ class Bandit(BaseService):
   def name(cls):           return 'bandit'
   @classmethod
   def _client_class(cls):  return jubatus.bandit.client.Bandit
+  @classmethod
+  def _embedded_class(cls):  return jubatus.embedded.Bandit
 
 class Burst(BaseService):
   CONFIG = {'method': 'burst', 'parameter': {'result_window_rotate_size': 5, 'max_reuse_batch_num': 5, 'batch_interval': 10, 'window_batch_size': 5, 'costcut_threshold': -1}}
@@ -40,6 +43,8 @@ class Burst(BaseService):
   def name(cls):           return 'burst'
   @classmethod
   def _client_class(cls):  return jubatus.burst.client.Burst
+  @classmethod
+  def _embedded_class(cls):  return jubatus.embedded.Burst
 
 class Clustering(BaseService):
   CONFIG = {'method': 'kmeans', 'parameter': {'k': 3, 'seed': 0}, 'compressor_method': 'simple', 'compressor_parameter': {'bucket_size': 1000}, 'converter': {'string_types': {'bigram': {'method': 'ngram', 'char_num': '2'}, 'trigram': {'method': 'ngram', 'char_num': '3'}, 'unigram': {'method': 'ngram', 'char_num': '1'}}, 'num_filter_types': {}, 'num_rules': [{'type': 'num', 'key': '*'}], 'num_filter_rules': [], 'string_filter_rules': [], 'num_types': {}, 'string_filter_types': {}, 'string_rules': [{'sample_weight': 'tf', 'global_weight': 'idf', 'type': 'bigram', 'key': '*'}]}}
@@ -48,6 +53,8 @@ class Clustering(BaseService):
   def name(cls):           return 'clustering'
   @classmethod
   def _client_class(cls):  return jubatus.clustering.client.Clustering
+  @classmethod
+  def _embedded_class(cls):  return jubatus.embedded.Clustering
 
 class Graph(BaseService):
   CONFIG = {'method': 'graph_wo_index', 'parameter': {'damping_factor': 0.9, 'landmark_num': 5}}
@@ -56,6 +63,8 @@ class Graph(BaseService):
   def name(cls):           return 'graph'
   @classmethod
   def _client_class(cls):  return jubatus.graph.client.Graph
+  @classmethod
+  def _embedded_class(cls):  return jubatus.embedded.Graph
 
 class NearestNeighbor(BaseService):
   CONFIG = {'method': 'lsh', 'parameter': {'hash_num': 64}, 'converter': {'string_types': {'bigram': {'method': 'ngram', 'char_num': '2'}, 'trigram': {'method': 'ngram', 'char_num': '3'}, 'unigram': {'method': 'ngram', 'char_num': '1'}}, 'num_filter_types': {}, 'num_rules': [{'type': 'num', 'key': '*'}], 'num_filter_rules': [], 'string_filter_rules': [], 'num_types': {}, 'string_filter_types': {}, 'string_rules': [{'sample_weight': 'tf', 'global_weight': 'idf', 'type': 'bigram', 'key': '*'}]}}
@@ -64,6 +73,8 @@ class NearestNeighbor(BaseService):
   def name(cls):           return 'nearest_neighbor'
   @classmethod
   def _client_class(cls):  return jubatus.nearest_neighbor.client.NearestNeighbor
+  @classmethod
+  def _embedded_class(cls):  return jubatus.embedded.NearestNeighbor
 
 class Recommender(BaseService):
   CONFIG = {'method': 'inverted_index', 'converter': {'string_types': {'bigram': {'method': 'ngram', 'char_num': '2'}, 'trigram': {'method': 'ngram', 'char_num': '3'}, 'unigram': {'method': 'ngram', 'char_num': '1'}}, 'num_filter_types': {}, 'num_rules': [{'type': 'num', 'key': '*'}], 'num_filter_rules': [], 'string_filter_rules': [], 'num_types': {}, 'string_filter_types': {}, 'string_rules': [{'sample_weight': 'tf', 'global_weight': 'idf', 'type': 'bigram', 'key': '*'}]}}
@@ -72,6 +83,8 @@ class Recommender(BaseService):
   def name(cls):           return 'recommender'
   @classmethod
   def _client_class(cls):  return jubatus.recommender.client.Recommender
+  @classmethod
+  def _embedded_class(cls):  return jubatus.embedded.Recommender
 
 class Regression(BaseService):
   CONFIG = {'method': 'PA1', 'parameter': {'sensitivity': 0.1, 'regularization_weight': 3.402823e+38}, 'converter': {'string_types': {'bigram': {'method': 'ngram', 'char_num': '2'}, 'trigram': {'method': 'ngram', 'char_num': '3'}, 'unigram': {'method': 'ngram', 'char_num': '1'}}, 'num_filter_types': {}, 'num_rules': [{'type': 'num', 'key': '*'}], 'num_filter_rules': [], 'string_filter_rules': [], 'num_types': {}, 'string_filter_types': {}, 'string_rules': [{'sample_weight': 'tf', 'global_weight': 'idf', 'type': 'bigram', 'key': '*'}]}}
@@ -80,6 +93,8 @@ class Regression(BaseService):
   def name(cls):           return 'regression'
   @classmethod
   def _client_class(cls):  return jubatus.regression.client.Regression
+  @classmethod
+  def _embedded_class(cls):  return jubatus.embedded.Regression
 
 class Stat(BaseService):
   CONFIG = {'window_size': 128}
@@ -88,3 +103,5 @@ class Stat(BaseService):
   def name(cls):           return 'stat'
   @classmethod
   def _client_class(cls):  return jubatus.stat.client.Stat
+  @classmethod
+  def _embedded_class(cls):  return jubatus.embedded.Stat

--- a/jubakit/recommender.py
+++ b/jubakit/recommender.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import jubatus
+import jubatus.embedded
 
 from .base import GenericSchema, BaseDataset, BaseService, GenericConfig
 from .compat import *
@@ -49,6 +50,10 @@ class Recommender(BaseService):
   @classmethod
   def _client_class(cls):
     return jubatus.recommender.client.Recommender
+
+  @classmethod
+  def _embedded_class(cls):
+    return jubatus.embedded.Recommender
 
   def update_row(self, dataset):
     """

--- a/jubakit/test/__init__.py
+++ b/jubakit/test/__init__.py
@@ -7,6 +7,12 @@ __all__ = ['requireSklearn']
 from jubakit.compat import PYTHON3
 
 try:
+  import embedded_jubatus
+  embedded_available = True
+except ImportError:
+  embedded_available = False
+
+try:
   import numpy
   import scipy
   import sklearn
@@ -20,8 +26,12 @@ try:
     return skipUnless(sklearn_available, 'requires scikit-learn')(target)
   def requirePython3(target):
     return skipUnless(PYTHON3, 'requires Python 3.x')(target)
+  def requireEmbedded(target):
+    return skipUnless(embedded_available, 'requires embedded_jubatus')(target)
 except ImportError:
   def requireSklearn(target):
     return target if sklearn_available else None
   def requirePython3(target):
     return target if PYTHON3 else None
+  def requireEmbedded(target):
+    return target if embedded_available else None

--- a/jubakit/test/test_anomaly.py
+++ b/jubakit/test/test_anomaly.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from jubakit.anomaly import Schema, Dataset, Anomaly, Config
 from jubakit.compat import *
 
+from . import requireEmbedded
 from .stub import *
 
 class SchemaTest(TestCase):
@@ -50,6 +51,10 @@ class DatasetTest(TestCase):
 class AnomalyTest(TestCase):
   def test_simple(self):
     anomaly = Anomaly()
+
+  @requireEmbedded
+  def test_embedded(self):
+    anomaly = Anomaly.run(Config(), embedded=True)
 
 class ConfigTest(TestCase):
   def test_simple(self):

--- a/jubakit/test/test_classifier.py
+++ b/jubakit/test/test_classifier.py
@@ -13,7 +13,7 @@ except ImportError:
 from jubakit.classifier import Schema, Dataset, Classifier, Config
 from jubakit.compat import *
 
-from . import requireSklearn
+from . import requireSklearn, requireEmbedded
 from .stub import *
 
 class SchemaTest(TestCase):
@@ -203,6 +203,10 @@ class DatasetTest(TestCase):
 class ClassifierTest(TestCase):
   def test_simple(self):
     classifier = Classifier()
+
+  @requireEmbedded
+  def test_embedded(self):
+    classifier = Classifier.run(Config(), embedded=True)
 
 class ConfigTest(TestCase):
   def test_simple(self):

--- a/jubakit/test/test_recommender.py
+++ b/jubakit/test/test_recommender.py
@@ -10,6 +10,7 @@ from unittest import TestCase
 from jubakit.recommender import Schema, Dataset, Recommender, Config
 from jubakit.compat import *
 
+from . import requireEmbedded
 from .stub import *
 
 def filter_warning():
@@ -45,6 +46,10 @@ class DatasetTest(TestCase):
 class RecommenderTest(TestCase):
   def test_simple(self):
     recommender = Recommender()
+
+  @requireEmbedded
+  def test_embedded(self):
+    recommender = Recommender.run(Config(), embedded=True)
 
   def test_update_row(self):
     recommender = Recommender.run(Config())

--- a/jubakit/test/test_weight.py
+++ b/jubakit/test/test_weight.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from jubakit.weight import Schema, Dataset, Weight, Config
 from jubakit.compat import *
 
+from . import requireEmbedded
 from .stub import *
 
 class SchemaTest(TestCase):
@@ -33,6 +34,10 @@ class DatasetTest(TestCase):
 class WeightTest(TestCase):
   def test_simple(self):
     weight = Weight()
+
+  @requireEmbedded
+  def test_embedded(self):
+    weight = Weight.run(Config(), embedded=True)
 
 class ConfigTest(TestCase):
   def test_simple(self):

--- a/jubakit/weight.py
+++ b/jubakit/weight.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import jubatus
+import jubatus.embedded
 
 from .base import GenericSchema, BaseDataset, BaseService, GenericConfig
 from .compat import *
@@ -34,6 +35,10 @@ class Weight(BaseService):
   @classmethod
   def _client_class(cls):
     return jubatus.weight.client.Weight
+
+  @classmethod
+  def _embedded_class(cls):
+    return jubatus.embedded.Weight
 
   def update(self, dataset):
     """


### PR DESCRIPTION
This PR adds support for "embedded" jubatus.

The new option ``embedded=True`` automatically creates new embedded instance instead of launching RPC server.
No other user changes needed.

```py
from jubakit.classifier import Config, Classifier

cfg = Config()
classifier_service = Classifier.run(cfg, embedded=True)
```