### PR TITLE
Add scikit-learn wrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,10 @@ See the `example <https://github.com/jubatus/jubakit/tree/master/example>`_ dire
 +-----------------------------------+-----------------------------------------------+-----------------------+
 | classifier_model_extract.py       | Extract contents of Classfier model file      |                       |
 +-----------------------------------+-----------------------------------------------+-----------------------+
+| classifier_sklearn_wrapper.py     | Classification using scikit-learn wrapper     | ✓                     |
++-----------------------------------+-----------------------------------------------+-----------------------+
+| classifier_sklearn_grid_search.py | Grid Search example using scikit-learn wrapper| ✓                     |
++-----------------------------------+-----------------------------------------------+-----------------------+
 | anomaly_auc.py                    | Anomaly detection and metrics                 |                       |
 +-----------------------------------+-----------------------------------------------+-----------------------+
 | recommender_npb.py                | Recommend similar items                       |                       |

--- a/example/classifier_sklearn_grid_search.py
+++ b/example/classifier_sklearn_grid_search.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+"""
+Grid Search with scikit-learn
+=============================
+
+In this example, we show how to use scikit-learn wrapper.
+
+"""
+
+import sklearn
+from operator import itemgetter
+from jubakit.wrapper import LinearClassifier, NearestNeighborsClassifier
+from sklearn.datasets import load_digits
+from sklearn.utils import shuffle
+from sklearn.pipeline import Pipeline
+from sklearn.decomposition import PCA
+# switch GridSearchCV API 
+sklearn_version = int(sklearn.__version__.split('.')[1])
+if sklearn_version < 18:
+    from sklearn.grid_search import GridSearchCV
+else:
+    from sklearn.model_selection import GridSearchCV
+
+# Grid Search parameters
+param_grid = {
+    'method': ['euclid_lsh', 'lsh'],
+    'nearest_neighbor_num': [4, 8, 16, 32],
+    'local_sensitivity':  [0.1, 1.0, 10],
+}
+
+# Sample dataset
+digits = load_digits()
+X, y = shuffle(digits.data, digits.target)
+
+# Launch Nearest Neighbor Classifier
+clf = NearestNeighborsClassifier(embedded=False, hash_num=128)
+
+# Execute Grid Search
+grid_search = GridSearchCV(clf, cv=4, n_jobs=-1, param_grid=param_grid, verbose=2)
+grid_search.fit(X, y)
+
+# Output the results.
+if sklearn_version < 18:
+    grid_scores = sorted(grid_search.grid_scores_, key=itemgetter(1), reverse=True)
+    for i, score in enumerate(grid_scores):
+        print('Rank:{0}\tScore:{1:.3f}\tParameter:{2}'.format(
+               i+1, score.mean_validation_score, score.parameters))
+else:
+    means = grid_search.cv_results_['mean_test_score']
+    params = grid_search.cv_results_['params']
+    grid_scores = sorted([(mean, param) for mean, param in zip(means, params)], key=itemgetter(0), reverse=True)
+    for i, grid_score in enumerate(grid_scores):
+        print('Rank:{0}\tScore:{1:.3f}\tParameter:{2}'.format(
+              i+1, grid_score[0], grid_score[1]))
+        

--- a/example/classifier_sklearn_grid_search.py
+++ b/example/classifier_sklearn_grid_search.py
@@ -13,7 +13,7 @@ In this example, we show how to use scikit-learn wrapper.
 
 import sklearn
 from operator import itemgetter
-from jubakit.wrapper import LinearClassifier, NearestNeighborsClassifier
+from jubakit.wrapper.classifier import LinearClassifier, NearestNeighborsClassifier
 from sklearn.datasets import load_digits
 from sklearn.utils import shuffle
 from sklearn.pipeline import Pipeline

--- a/example/classifier_sklearn_wrapper.py
+++ b/example/classifier_sklearn_wrapper.py
@@ -12,7 +12,7 @@ In this example, we show how to use scikit-learn wrapper's
 
 """
 
-from jubakit.wrapper import LinearClassifier, NearestNeighborsClassifier
+from jubakit.classifier.wrapper import LinearClassifier, NearestNeighborsClassifier
 
 from sklearn.datasets import load_digits
 from sklearn.decomposition import PCA

--- a/example/classifier_sklearn_wrapper.py
+++ b/example/classifier_sklearn_wrapper.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+""" 
+Pipeline Classification with scikit-learn wrapped Classifier
+============================================================
+
+In this example, we show how to use scikit-learn wrapper's 
+`fit(X, y)` and `predict(X)` functions. 
+
+"""
+
+from jubakit.wrapper import LinearClassifier, NearestNeighborsClassifier
+
+from sklearn.datasets import load_digits
+from sklearn.decomposition import PCA
+from sklearn.preprocessing import StandardScaler
+from sklearn.metrics import classification_report
+from sklearn.pipeline import Pipeline
+from sklearn.utils import shuffle
+
+# load hand-writtern number recognition dataset
+digits = load_digits()
+# shuffle and separate the dataset
+X, y = shuffle(digits.data, digits.target, random_state=42)
+n_train = int(X.shape[0] / 2) 
+X_train, y_train = X[:n_train], y[:n_train]
+X_test, y_test = X[n_train:], y[n_train:]
+
+# launch linear classifier (AROW)
+clf = LinearClassifier(method='AROW', embedded=False, seed=42)
+
+# scale dataset 
+scaled_pipeline = Pipeline([
+    ('scaler', StandardScaler()),
+    ('classifier', clf)
+])
+
+# decompose dataset
+pca_pipeline = Pipeline([
+    ('pca', PCA()),
+    ('classifier', clf)
+])
+
+# evaluate each pipelines
+pipelines = [clf, scaled_pipeline, pca_pipeline]
+for pipeline in pipelines:
+    print(pipeline)
+    pipeline.fit(X_train, y_train)
+    y_pred = pipeline.predict(X_test)
+    print(classification_report(y_test, y_pred))
+
+

--- a/example/classifier_sklearn_wrapper.py
+++ b/example/classifier_sklearn_wrapper.py
@@ -12,7 +12,7 @@ In this example, we show how to use scikit-learn wrapper's
 
 """
 
-from jubakit.classifier.wrapper import LinearClassifier, NearestNeighborsClassifier
+from jubakit.wrapper.classifier import LinearClassifier, NearestNeighborsClassifier
 
 from sklearn.datasets import load_digits
 from sklearn.decomposition import PCA

--- a/jubakit/test/test_wrapper.py
+++ b/jubakit/test/test_wrapper.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+try:
+  import numpy as np
+except ImportError:
+  pass
+
+from jubakit.wrapper import LinearClassifier, NearestNeighborsClassifier
+from . import requireEmbedded
+
+
+class LinearClassifierTest(TestCase):
+  
+  def test_simple(self):
+    classifier = LinearClassifier()
+    classifier.stop()
+
+  @requireEmbedded
+  def test_embedded(self):
+    classifier = LinearClassifier(embedded=True)
+
+  @requireEmbedded
+  def test_launch_classifier(self):
+    methods = ['AROW', 'CW', 'NHERD', 'PA', 'PA1', 'PA2', 'perceptron']
+    def launch_classifier(method):
+      classifier = LinearClassifier(method=method)
+      classifier._launch_classifier()
+    for method in methods:
+      self.assertEqual(launch_classifier(method), None)
+    self.assertRaises(NotImplementedError, launch_classifier, 'Logistic Regression')
+
+  @requireEmbedded
+  def test_partial_fit(self):
+    X = np.array([[1,1], [0,0]])
+    y = np.array([1,2])
+    classifier = LinearClassifier()
+    self.assertTrue(classifier.clf_ is None)
+    self.assertEqual(classifier.fitted_, False)
+    classifier.partial_fit(X, y)
+    self.assertTrue(classifier.clf_ is not None)
+    self.assertEqual(classifier.fitted_, True)
+
+  @requireEmbedded
+  def test_predict(self):
+    X = np.array([[1,1], [0,0]])
+    y = np.array([1,2])
+    classifier = LinearClassifier()
+    self.assertRaises(RuntimeError, classifier.predict, X)
+    classifier.fit(X, y)
+    y_pred = classifier.predict(X)
+    self.assertEqual(y_pred.shape[0], X.shape[0])
+  
+  @requireEmbedded
+  def test_decision_function(self):
+    X = np.array([[1,1], [0,0]])
+    y = np.array([1,2])
+    c = np.unique(y)
+    classifier = LinearClassifier()
+    self.assertRaises(RuntimeError, classifier.predict, X)
+    classifier.fit(X, y)
+    y_pred = classifier.decision_function(X)
+    self.assertEqual(y_pred.shape, (X.shape[0], c.shape[0]))
+
+  @requireEmbedded
+  def test_class_params(self):
+    classifier = LinearClassifier()
+    params = ['method', 'regularization_weight',
+              'softmax', 'n_iter', 'shuffle', 'embedded', 'seed']
+    for param in params:
+      self.assertTrue(param in classifier.__dict__)
+    self.assertTrue('invalid_param' not in classifier.__dict__)
+
+  @requireEmbedded
+  def test_get_params(self):
+    params = {
+      'method': 'CW', 
+      'regularization_weight': 5.0,
+      'softmax': True,
+      'n_iter': 5,
+      'shuffle': True,
+      'embedded': True,
+      'seed': 42
+    }
+    classifier = LinearClassifier(**params)
+    self.assertDictEqual(params, classifier.get_params())
+    classifier.stop()
+
+  @requireEmbedded
+  def test_set_params(self):
+    params = {
+      'method': 'CW', 
+      'regularization_weight': 5.0,
+      'softmax': True,
+      'n_iter': 5,
+      'shuffle': True,
+      'embedded': True,
+      'seed': 42
+    }
+    classifier = LinearClassifier()
+    classifier.set_params(**params)
+    self.assertEqual(classifier.method, params['method'])
+    self.assertEqual(classifier.regularization_weight, params['regularization_weight'])
+    self.assertEqual(classifier.softmax, params['softmax'])
+    self.assertEqual(classifier.n_iter, params['n_iter'])
+    self.assertEqual(classifier.shuffle, params['shuffle'])
+    self.assertEqual(classifier.embedded, params['embedded'])
+    self.assertEqual(classifier.seed, params['seed'])
+
+  @requireEmbedded
+  def test_save(self):
+    name = 'test'
+    classifier = LinearClassifier()
+    classifier.save(name)
+
+
+class NearestNeighborsClassifierTest(TestCase):
+  
+  def test_simple(self):
+    classifier = NearestNeighborsClassifier()
+    classifier.stop()
+
+  @requireEmbedded
+  def test_embedded(self):
+    classifier = NearestNeighborsClassifier(embedded=True)
+
+  @requireEmbedded
+  def test_launch_classifier(self):
+    methods = ['euclid_lsh', 'lsh', 'minhash', 'euclidean', 'cosine']
+    def launch_classifier(method):
+      classifier = NearestNeighborsClassifier(method=method)
+      classifier._launch_classifier()
+    for method in methods:
+      self.assertEqual(launch_classifier(method), None)
+    self.assertRaises(NotImplementedError, launch_classifier, 'inverted_index')
+
+  @requireEmbedded
+  def test_partial_fit(self):
+    X = np.array([[1,1], [0,0]])
+    y = np.array([1,2])
+    classifier = NearestNeighborsClassifier()
+    self.assertTrue(classifier.clf_ is None)
+    self.assertEqual(classifier.fitted_, False)
+    classifier.partial_fit(X, y)
+    self.assertTrue(classifier.clf_ is not None)
+    self.assertEqual(classifier.fitted_, True)
+    classifier.stop()
+
+  @requireEmbedded
+  def test_predict(self):
+    X = np.array([[1,1], [0,0]])
+    y = np.array([1,2])
+    classifier = NearestNeighborsClassifier()
+    self.assertRaises(RuntimeError, classifier.predict, X)
+    classifier.fit(X, y)
+    y_pred = classifier.predict(X)
+    self.assertEqual(y_pred.shape[0], X.shape[0])
+
+  @requireEmbedded
+  def test_decision_function(self):
+    X = np.array([[1,1], [0,0]])
+    y = np.array([1,2])
+    c = np.unique(y)
+    classifier = NearestNeighborsClassifier()
+    self.assertRaises(RuntimeError, classifier.predict, X)
+    classifier.fit(X, y)
+    y_pred = classifier.decision_function(X)
+    self.assertEqual(y_pred.shape, (X.shape[0], c.shape[0]))
+
+  @requireEmbedded
+  def test_class_params(self):
+    classifier = NearestNeighborsClassifier()
+    params = ['method', 'nearest_neighbor_num', 'local_sensitivity',
+              'hash_num', 'softmax', 'n_iter', 'shuffle', 'embedded', 'seed']
+    for param in params:
+      self.assertTrue(param in classifier.__dict__)
+    self.assertTrue('invalid_param' not in classifier.__dict__)
+
+  @requireEmbedded
+  def test_get_params(self):
+    params = {
+      'method': 'lsh', 
+      'nearest_neighbor_num': 10,
+      'local_sensitivity': 0.1,
+      'hash_num': 512,
+      'softmax': True,
+      'n_iter': 5,
+      'shuffle': True,
+      'embedded': True,
+      'seed': 42
+    }
+    classifier = NearestNeighborsClassifier(**params)
+    self.assertDictEqual(params, classifier.get_params())
+
+  @requireEmbedded
+  def test_set_params(self):
+    params = {
+      'method': 'lsh', 
+      'nearest_neighbor_num': 10,
+      'local_sensitivity': 0.1,
+      'hash_num': 512,
+      'softmax': True,
+      'n_iter': 5,
+      'shuffle': True,
+      'embedded': True,
+      'seed': 42
+    }
+    classifier = NearestNeighborsClassifier()
+    classifier.set_params(**params)
+    self.assertEqual(classifier.method, params['method'])
+    self.assertEqual(classifier.nearest_neighbor_num, params['nearest_neighbor_num'])
+    self.assertEqual(classifier.local_sensitivity, params['local_sensitivity'])
+    self.assertEqual(classifier.hash_num, params['hash_num'])
+    self.assertEqual(classifier.softmax, params['softmax'])
+    self.assertEqual(classifier.n_iter, params['n_iter'])
+    self.assertEqual(classifier.shuffle, params['shuffle'])
+    self.assertEqual(classifier.embedded, params['embedded'])
+    self.assertEqual(classifier.seed, params['seed'])
+   
+  @requireEmbedded
+  def test_save(self):
+    name = 'test'
+    classifier = NearestNeighborsClassifier()
+    classifier.save(name)
+
+

--- a/jubakit/test/wrapper/test_classifier.py
+++ b/jubakit/test/wrapper/test_classifier.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
   pass
 
-from jubakit.wrapper import LinearClassifier, NearestNeighborsClassifier
+from jubakit.wrapper.classifier import LinearClassifier, NearestNeighborsClassifier
 from . import requireEmbedded
 
 

--- a/jubakit/wrapper.py
+++ b/jubakit/wrapper.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from sklearn.base import BaseEstimator, ClassifierMixin
+from .classifier import Classifier, Config, Dataset
+
+
+class BaseJubatusClassifier(BaseEstimator, ClassifierMixin):
+  """
+  scikit-learn Wrapper for Jubatus Classifiers.
+  """
+  
+  def __init__(self, n_iter=1, shuffle=False, softmax=False, embedded=True, seed=None):
+    """
+    Creates a base class for Jubatus Classifiers"
+    """
+    self.softmax = softmax
+    self.n_iter = n_iter
+    self.shuffle = shuffle
+    self.embedded = embedded
+    self.seed = seed
+    self.fitted_ = False
+    self.clf_ = None
+
+  @classmethod
+  def _launch_classifier(self):
+    """ 
+    Launch Jubatus Classifier 
+    """
+    raise NotImplementedError()
+
+  def partial_fit(self, X, y):
+    """
+    Partially fit underlying model.
+    If underlying model does not exist, launch a new model.
+    """
+    if getattr(self, 'classes_', None) is None:
+      self.classes_ = np.unique(y)
+    if self.clf_ is None:
+      self._launch_classifier()
+      if not self.embedded:
+        self.clf_.clear()
+    dataset = Dataset.from_data(X, y)
+    for i in range(self.n_iter):
+      if self.shuffle:
+        dataset = dataset.shuffle(self.seed)
+      for _ in self.clf_.train(dataset): pass
+    self.fitted_ = True
+    return self
+
+  def fit(self, X, y):
+    """
+    Fit model.
+    """
+    self._launch_classifier()
+    if not self.embedded:
+      self.clf_.clear()
+    return self.partial_fit(X, y)
+
+  def predict(self, X):
+    """
+    Predict class labels for samples in X.
+    """
+    if not self.fitted_:
+      raise RuntimeError('This estimator instance is not fitted yet.')
+    y_pred = np.empty(X.shape[0], dtype=self.classes_.dtype)
+    dataset = Dataset.from_data(X)
+    for idx, _, result in self.clf_.classify(dataset, softmax=self.softmax):
+      y_pred[idx] = result[0][0]
+    return y_pred
+
+  def decision_function(self, X):
+    """
+    Predict confidence scores for samples.
+    """
+    if not self.fitted_:
+      raise RuntimeError('This estimator instance is not fitted yet.')
+    scores = np.empty((X.shape[0], len(self.classes_)))
+    dataset = Dataset.from_data(X)
+    for idx, _, result in self.clf_.classify(dataset, softmax=self.softmax):
+      for (label, score) in result:
+        scores[idx][np.searchsorted(self.classes_, label)] = score
+    return scores
+
+  @classmethod
+  def get_params(self, deep=True):
+    """ 
+    Return Parameters 
+    """
+    raise NotImplementedError()
+  
+  def set_params(self, **params):
+    """
+    Set Parameters
+    """
+    for param, value in params.items():
+      setattr(self, param, value)
+    return self
+
+  def save(self, name):
+    """  
+    Save the classifier model using name.
+    """
+    if self.clf_ is not None:
+      self.clf_.save(name)
+
+  def stop(self):
+    """
+    Stop the backend process if exists.
+    """
+    if not self.embedded and self.clf_ is not None:
+      self.clf_.stop()
+      self.clf_ = None
+
+
+class LinearClassifier(BaseJubatusClassifier):
+  
+  def __init__(self, method='AROW', regularization_weight=1.0, 
+               softmax=False, n_iter=1, shuffle=False, embedded=True, seed=None):
+    super(LinearClassifier, self).__init__(n_iter, shuffle, softmax, embedded, seed)
+    self.method = method
+    self.regularization_weight = regularization_weight
+  
+  def _launch_classifier(self):
+    if self.method in ('perceptron', 'PA'):
+      self.cfg_ = Config(method=self.method)
+    elif self.method in ('PA1', 'PA2', 'CW', 'AROW', 'NHERD'):
+      self.cfg_ = Config(method=self.method, 
+                            parameter={'regularization_weight': self.regularization_weight})
+    else:
+      raise NotImplementedError('method {} is not implememented yet.'.format(self.method))
+    self.clf_ = Classifier.run(config=self.cfg_, embedded=self.embedded) 
+
+  def get_params(self, deep=True):
+    return {
+      'method': self.method,
+      'regularization_weight': self.regularization_weight,
+      'n_iter': self.n_iter,
+      'shuffle': self.shuffle,
+      'softmax': self.softmax,
+      'embedded': self.embedded,
+      'seed': self.seed
+    }
+
+
+class NearestNeighborsClassifier(BaseJubatusClassifier):
+  
+  def __init__(self, method='euclid_lsh', nearest_neighbor_num=5, local_sensitivity=1.0,
+               hash_num=128, n_iter=1, shuffle=False, softmax=False, embedded=True, seed=None):
+    super(NearestNeighborsClassifier, self).__init__(n_iter, shuffle, softmax, embedded, seed)
+    self.method = method
+    self.nearest_neighbor_num = nearest_neighbor_num
+    self.local_sensitivity = local_sensitivity
+    self.hash_num = hash_num
+
+  def _launch_classifier(self):
+    if self.method in ('euclid_lsh', 'lsh', 'minhash'):
+      self.cfg_ = Config(method='NN', parameter={'method': self.method,
+                                                 'nearest_neighbor_num': self.nearest_neighbor_num,
+                                                 'local_sensitivity': self.local_sensitivity,
+                                                 'parameter': {'hash_num': self.hash_num}})
+    elif self.method in ('euclidean', 'cosine'):
+      self.cfg_ = Config(method=self.method, 
+                         parameter={'nearest_neighbor_num': self.nearest_neighbor_num,
+                                    'local_sensitivity': self.local_sensitivity})
+    else:
+      raise NotImplementedError('method {} is not implememented yet.'.format(self.method))                            
+    self.clf_ = Classifier.run(config=self.cfg_, embedded=self.embedded) 
+
+  def get_params(self, deep=True):
+    return {
+      'method': self.method,
+      'nearest_neighbor_num': self.nearest_neighbor_num,
+      'local_sensitivity': self.local_sensitivity,
+      'hash_num': self.hash_num,
+      'n_iter': self.n_iter,
+      'shuffle': self.shuffle,
+      'softmax': self.softmax,
+      'embedded': self.embedded,
+      'seed': self.seed
+    }

--- a/jubakit/wrapper/classifier.py
+++ b/jubakit/wrapper/classifier.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
-from .classifier import Classifier, Config, Dataset
+from ..classifier import Classifier, Config, Dataset
 
 
 class BaseJubatusClassifier(BaseEstimator, ClassifierMixin):


### PR DESCRIPTION
This PR enables us to cooperate scikit-learn more easily.

We now can use jubatus with scikit-learn APIs like [Pipeline API](http://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html) , [Cross Validation API](http://scikit-learn.org/stable/modules/generated/sklearn.cross_validation.cross_val_score.html#sklearn.cross_validation.cross_val_score), [Grid Search API](http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html#sklearn.model_selection.GridSearchCV) and so on.