### PR TITLE
fix color of version number in docs

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -13,6 +13,15 @@
     border-color: #a47224 !important;
 }
 
+a.icon, a.icon-home {
+    color: #333333 !important;
+}
+
+div.version {
+    color: #333333 !important;
+    font-weight: bold !important;
+}
+
 body {
     font-family: 'Lucida Grande', 'Lucida Sans Unicode', 'Geneva',
                  'Verdana', sans-serif;


### PR DESCRIPTION
This fixes #80 .

![jubakit_version_number](https://cloud.githubusercontent.com/assets/8208713/24433781/0816388c-1466-11e7-8c21-f3b5c7dd50d4.png)
