### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - 2.6
     - 2.7
     - 3.3
     - 3.4
@@ -19,7 +18,7 @@ install:
     - source /opt/jubatus/profile
 
     # Install Conda (see http://conda.pydata.org/docs/travis.html)
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" || "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
       else
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Install
 Requirements
 ------------
 
-* Python 2.6, 2.7, 3.3, 3.4 or 3.5.
+* Python 2.7, 3.3, 3.4 or 3.5.
 * `Jubatus <http://jubat.us/en/quickstart.html>`_ needs to be installed.
 * Although not mandatory, `installing scikit-learn <http://scikit-learn.org/stable/install.html>`_ is required to use some features like K-fold cross validation.
 

--- a/jubakit/_cli/util.py
+++ b/jubakit/_cli/util.py
@@ -17,9 +17,6 @@ __all__ = [
 ]
 
 def shell_split(s):
-  if isinstance(s, unicode_t) and PYTHON2_6:
-    # shlex does not support Unicode on Python 2.6
-    return map(lambda x: x.decode(), shlex.split(s.encode()))
   return shlex.split(s)
 
 def comp_position(text, line, begidx, endidx):

--- a/jubakit/compat.py
+++ b/jubakit/compat.py
@@ -12,7 +12,6 @@ except ImportError:
   # Python 2
   import __builtin__ as builtins
 
-PYTHON2_6 = sys.version_info[:2] == (2, 6)
 PYTHON3 = sys.version_info >= (3, 0)
 
 zip_longest = itertools.zip_longest if PYTHON3 else itertools.izip_longest

--- a/jubakit/model.py
+++ b/jubakit/model.py
@@ -671,7 +671,6 @@ class _JubaModelCommand(object):
 
     EPILOG = '  model_file            input model file in format specified by --in-format'
 
-    # TODO: migrate to argparse (which must be added into dependency to support Python 2.6)
     parser = _JubaModelOptionParser(add_help_option=False, usage=USAGE, epilog=EPILOG)
 
     # arguments

--- a/jubakit/shell.py
+++ b/jubakit/shell.py
@@ -359,7 +359,6 @@ class _JubashCommand(object):
 
     services = sorted(JubaShell.get_cli_classes().keys())
 
-    # TODO: migrate to argparse (which must be added into dependency to support Python 2.6)
     parser = _JubashOptionParser(add_help_option=False, usage=USAGE, epilog=EPILOG)
 
     parser.add_option('-H', '--host', type='string', default='127.0.0.1',

--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,10 @@ def _read(filename):
 exec(_read('jubakit/_version.py'))
 
 def get_extras_requires():
-  if sys.version_info < (2, 7):
-    extras_requires = {
-      'test': ['numpy<=1.10.3', 'scipy<=0.16.1',
-               'scikit-learn', 'tweepy', 'jq'],
-    }
-  else:
-    extras_requires = {
-      'test': ['numpy', 'scipy',
-               'scikit-learn', 'tweepy', 'jq'],
-    }
+  extras_requires = {
+    'test': ['numpy', 'scipy',
+             'scikit-learn', 'tweepy', 'jq'],
+  }
   return extras_requires
 
 setup(name='jubakit',
@@ -39,7 +33,6 @@ setup(name='jubakit',
           'License :: OSI Approved :: MIT License',
           'Programming Language :: Python',
           'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py27, py33, py34, py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
Python 2.6 is now EOL and is no longer supported by the Python core team.
Related to #99 , coverall doesn't support Python 2.6.

For these reasons I want to drop support for Python 2.6.