### PR TITLE
Add postgresql loader

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/architecture/loader.po
+++ b/doc/locale/ja/LC_MESSAGES/architecture/loader.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jubakit 0.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-03 22:56+0900\n"
+"POT-Creation-Date: 2018-10-06 22:55+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,16 +28,14 @@ msgid ""
 ":py:class:`CSVLoader <jubakit.loader.csv.CSVLoader>` class to load CSV "
 "dataset."
 msgstr ""
-"Loaderはデータソースからデータを取得する機能を提供します。"
-"Loaderクラスはデータソース毎に実装されています。"
-"例えばCSVのデータセットのロードには :py:class:`CSVLoader <jubakit.loader.csv.CSVLoader>` を使います。"
+"Loaderはデータソースからデータを取得する機能を提供します。Loaderクラスはデータソース毎に実装されています。例えばCSVのデータセットのロードには"
+" :py:class:`CSVLoader <jubakit.loader.csv.CSVLoader>` を使います。"
+
 #: ../../source/architecture/loader.rst:14
 msgid ""
 "The Loader outputs a dict-like (key-value) object for each record loaded "
 "from the data source:"
-msgstr ""
-"Loaderの出力はデータソースから読み込んだレコード毎に辞書形式のオブジェクトとなります。"
-
+msgstr "Loaderの出力はデータソースから読み込んだレコード毎に辞書形式のオブジェクトとなります。"
 
 #: ../../source/architecture/loader.rst:25
 msgid "List of Loaders"
@@ -55,8 +53,7 @@ msgstr "一行ごとに処理するプレーンテキストのストリームや
 msgid ""
 "Array-like (Python lists, NumPy arrays, etc.) data structure -- "
 ":py:mod:`jubakit.loader.array`"
-msgstr ""
-"配列形式(PythonのリストやNumPyのarrayなど) -- :py:mod:`jubakit.loader.array`"
+msgstr "配列形式(PythonのリストやNumPyのarrayなど) -- :py:mod:`jubakit.loader.array`"
 
 #: ../../source/architecture/loader.rst:31
 msgid "SciPy sparse matrix data structure -- :py:mod:`jubakit.loader.sparse`"
@@ -67,20 +64,24 @@ msgid "CSV files -- :py:mod:`jubakit.loader.csv`"
 msgstr "CSVファイル -- :py:mod:`jubakit.loader.csv`"
 
 #: ../../source/architecture/loader.rst:33
+msgid "PostgreSQL data -- :py:mod:`jubakit.loader.postgresql`"
+msgstr "PostgreSQLのデータ -- :py:mod:`jubakit.loader.postgresql`"
+
+#: ../../source/architecture/loader.rst:34
 msgid "Twitter streams -- :py:mod:`jubakit.loader.twitter`"
 msgstr "Twitterのストリーム -- :py:mod:`jubakit.loader.twitter`"
 
-#: ../../source/architecture/loader.rst:34
+#: ../../source/architecture/loader.rst:35
 msgid ""
 "*Chain* Loaders (that wraps other Loaders) -- "
 ":py:mod:`jubakit.loader.chain`"
 msgstr "他のLoaderをラップするLoader(*Chain* Loader) -- :py:mod:`jubakit.loader.chain`"
 
-#: ../../source/architecture/loader.rst:36
+#: ../../source/architecture/loader.rst:37
 msgid ""
 "You can extend these Loaders or even write your own one. See "
 ":doc:`../guide/loader_develop` for details."
 msgstr ""
-"Loaderを拡張することや自分でLoaderを実装することもできます。"
-"詳しくは :doc:`../guide/loader_develop` を参照してください。"
+"Loaderを拡張することや自分でLoaderを実装することもできます。詳しくは :doc:`../guide/loader_develop` "
+"を参照してください。"
 

--- a/doc/source/architecture/loader.rst
+++ b/doc/source/architecture/loader.rst
@@ -30,6 +30,7 @@ Loaders for the following data sources are bundled with Jubakit.
 * Array-like (Python lists, NumPy arrays, etc.) data structure -- :py:mod:`jubakit.loader.array`
 * SciPy sparse matrix data structure -- :py:mod:`jubakit.loader.sparse`
 * CSV files -- :py:mod:`jubakit.loader.csv`
+* PostgreSQL data -- :py:mod:`jubakit.loader.postgresql`
 * Twitter streams -- :py:mod:`jubakit.loader.twitter`
 * *Chain* Loaders (that wraps other Loaders) -- :py:mod:`jubakit.loader.chain`
 

--- a/jubakit/loader/postgresql.py
+++ b/jubakit/loader/postgresql.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ..base import BaseLoader
+from ..compat import *
+from psycopg2 import connect
+from psycopg2.extras import DictCursor
+from psycopg2 import sql
+
+class PostgreSQLoader(BaseLoader):
+  """
+  Loader to process columns of PostgreSQL.
+
+  This loader that load data from PostgreSQL's table as below.
+  We access the "test" table of the "test" database in the below example.
+
+  Example:
+    from jubakit.loader.postgresql import PostgreSQLoader
+    from jubakit.loader.postgresql import PostgreSQLAuthHandler
+    
+    auth = PostgreSQLAuthHandler(dbname='test', user='postgres', password='postgres', host='localhost', port='5432')
+    
+    loader = PostgreSQLoader(auth, table='test')
+    for row in loader:
+      print(row)
+    
+    # {'id': 1, 'num': 100, 'data': 'abcdef'}
+    # {'id': 2, 'num': 200, 'data': 'ghijkl'}
+    # {'id': 3, 'num': 300, 'data': 'mnopqr'}
+  """
+
+  def __init__(self, auth, table, **kwargs):
+    self.auth = auth
+    self.table = table
+    self.kwargs = kwargs
+
+  def rows(self):
+    with connect(self.auth.get()) as connection:
+      with connection.cursor(cursor_factory=DictCursor) as cursor:
+        cursor.execute(
+          sql.SQL("SELECT * FROM {}")
+          .format(sql.Identifier(self.table)))
+        column_names = [column.name for column in cursor.description]
+
+        for row in cursor:
+          yield dict(zip(column_names, row))
+
+class PostgreSQLAuthHandler(object):
+  """
+  Handles authentication required to access PostgreSQL.
+  """
+
+  def __init__(self, **kwargs):
+    """
+    Authentication information must be specified as follows:
+
+    >>> PostgreSQLAuth(
+    ...   user='XXXXXXXXXXXXXXXXXXXX',
+    ...   password='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    ...   host='XXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    ...   port='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    ... )
+
+    Any other connection parameter supported by this loader can be passed as a keyword.
+    The complete list of the supported parameters are contained the PostgreSQL documentation.
+    (https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS)
+    """
+    auth = ''
+    auth_informations = (
+      'host', 'hostaddr',
+      'port',
+      'dbname',
+      'user',
+      'password', 'passfile',
+      'connect_timeout',
+      'client_encoding',
+      'options',
+      'application_name',
+      'fallback_application_name',
+      'keepalives', 'keepalives_idle', 'keepalives_interval', 'keepalives_count',
+      'tty',
+      'sslmode', 'requiressl', 'sslcompression', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl',
+      'requirepeer',
+      'krbsrvname',
+      'gsslib',
+      'service',
+      'target_session_attrs')
+    for auth_key in auth_informations:
+      if auth_key in kwargs:
+        auth = auth + '%s=%s ' % (auth_key, kwargs[auth_key])
+    self.auth = auth
+
+  def get(self):
+    return self.auth

--- a/jubakit/test/loader/test_postgresql.py
+++ b/jubakit/test/loader/test_postgresql.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from unittest import TestCase
+
+from jubakit.loader.postgresql import PostgreSQLoader
+from jubakit.loader.postgresql import PostgreSQLAuthHandler
+
+import psycopg2
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+class PostgreSQLoaderTest(TestCase):
+  auth = PostgreSQLAuthHandler(user='postgres', password='postgres', host='localhost', port='5432')
+
+  def setUp(self):
+    print("setUp")
+    connection = psycopg2.connect("host=localhost port=5432 user=postgres password=postgres")
+    connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    cursor = connection.cursor()
+    cursor.execute("DROP DATABASE IF EXISTS test;")
+    cursor.execute("CREATE DATABASE test;")
+
+    cursor.execute("DROP TABLE IF EXISTS test;")
+    cursor.execute("CREATE TABLE test (id serial PRIMARY KEY, num integer, data varchar);")
+    cursor.execute("INSERT INTO test (num, data) VALUES (%s, %s)", (100, "abcdef"))
+    cursor.execute("INSERT INTO test (num, data) VALUES (%s, %s)", (200, "ghijkl"))
+    cursor.execute("INSERT INTO test (num, data) VALUES (%s, %s)", (300, "mnopqr"))
+
+    connection.commit()
+    connection.close()
+
+    connection = psycopg2.connect("dbname=test host=localhost port=5432 user=postgres password=postgres")
+    cursor = connection.cursor()
+
+    cursor.execute("DROP TABLE IF EXISTS test2;")
+    cursor.execute("CREATE TABLE test2 (id serial PRIMARY KEY, num integer, data varchar);")
+    cursor.execute("INSERT INTO test2 (num, data) VALUES (%s, %s)", (1000, "st"))
+    cursor.execute("INSERT INTO test2 (num, data) VALUES (%s, %s)", (2000, "uv"))
+    cursor.execute("INSERT INTO test2 (num, data) VALUES (%s, %s)", (3000, "wx"))
+
+    connection.commit()
+    connection.close()
+
+  def test_simple(self):
+    loader = PostgreSQLoader(self.auth, table='test')
+    for row in loader:
+      self.assertEqual(set(['id','num', 'data']), set(row.keys()))
+      if row['id'] == 1:
+        self.assertEqual(100, row['num'])
+        self.assertEqual('abcdef', row['data'])
+      elif row['id'] == 2:
+        self.assertEqual(200, row['num'])
+        self.assertEqual('ghijkl', row['data'])
+      elif row['id'] == 3:
+        self.assertEqual(300, row['num'])
+        self.assertEqual('mnopqr', row['data'])
+      else:
+        self.fail('unexpected row: {0}'.format(row))
+
+  def test_specify_dbname(self):
+    self.auth = PostgreSQLAuthHandler(dbname='test', user='postgres', password='postgres', host='localhost', port='5432')
+    loader = PostgreSQLoader(self.auth, table='test2')
+    for row in loader:
+      self.assertEqual(set(['id','num', 'data']), set(row.keys()))
+      if row['id'] == 1:
+        self.assertEqual(1000, row['num'])
+        self.assertEqual('st', row['data'])
+      elif row['id'] == 2:
+        self.assertEqual(2000, row['num'])
+        self.assertEqual('uv', row['data'])
+      elif row['id'] == 3:
+        self.assertEqual(3000, row['num'])
+        self.assertEqual('wx', row['data'])
+      else:
+        self.fail('unexpected row: {0}'.format(row))
+
+  def tearDown(self):
+    print("tearDown")
+    connection = psycopg2.connect("host=localhost port=5432 user=postgres password=postgres")
+    connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    cursor = connection.cursor()
+
+    cursor.execute("DROP DATABASE test;")
+    cursor.execute("DROP TABLE test;")
+    connection.commit()
+    connection.close()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ exec(_read('jubakit/_version.py'))
 def get_extras_requires():
   extras_requires = {
     'test': ['numpy', 'scipy',
-             'scikit-learn', 'tweepy', 'jq'],
+             'scikit-learn', 'tweepy', 'jq', 'psycopg2'],
   }
   return extras_requires
 


### PR DESCRIPTION
Dear developers,

I tried making a new loader.
This loader that load data from PostgreSQL's table as below.

```
from jubakit.loader.postgresql import PostgreSQLoader
from jubakit.loader.postgresql import PostgreSQLAuthHandler

auth = PostgreSQLAuthHandler(user='postgres', password='postgres', host='localhost', port='5432')

loader = PostgreSQLoader(auth, table='test')
for row in loader:
  print(row)

# [1, 100, 'abcdef']
# [2, 200, 'ghijkl']
# [3, 300, 'mnopqr']
```
I suppose this loader likely to be used generally.
Therefore, I send a pull request.

However, we need installing psycopg2 additional for use this loader.