### PR TITLE
fix twitter loader to follow tweepy api

### DIFF
--- a/jubakit/loader/twitter.py
+++ b/jubakit/loader/twitter.py
@@ -80,7 +80,7 @@ class TwitterStreamLoader(BaseLoader):
     if start_stream is None:
       raise RuntimeError('unknown stream mode: {0}'.format(mode))
 
-    kwargs['async'] = False
+    kwargs['is_async'] = False
     self._thread = threading.Thread(target=start_stream, kwargs=kwargs)
     self._thread.daemon = True
 


### PR DESCRIPTION
Tweepy API changed to use `is_async`, not `async` and I fixed it.

Please see tweepy github pages for details https://github.com/tweepy/tweepy/pull/1042